### PR TITLE
Fix PHP warning about is_uploaded_file()

### DIFF
--- a/php/functions.php
+++ b/php/functions.php
@@ -117,7 +117,7 @@ function upload($files, $albumID) {
 	    $data = $data[0];
 
 	    // Import if not uploaded via web
-	    if (!is_uploaded_file($file)) {
+	    if (!is_uploaded_file($tmp_name)) {
 	    	if (copy($tmp_name, "../uploads/big/" . md5($id) . ".$data")) {
 				unlink($tmp_name);
 				$import_name = $tmp_name;


### PR DESCRIPTION
I am receiving PHP warnings like this:

```
PHP Warning:  is_uploaded_file() expects parameter 1 to be string, array given in /home/ecotopia/Lychee/php/functions.php on line 119
```

I believe this commit fixes that issue.
