### PR TITLE
check.php an permission checks?

### DIFF
--- a/plugins/check.php
+++ b/plugins/check.php
@@ -54,7 +54,7 @@ if (substr(sprintf('%o', @fileperms('../uploads/big/')), -4)!='0777')	$error .= 
 if (substr(sprintf('%o', @fileperms('../uploads/thumb/')), -4)!='0777')	$error .= ('Error 501: Wrong permissions for \'uploads/thumb\' (777 required)' . PHP_EOL);
 if (substr(sprintf('%o', @fileperms('../uploads/import/')), -4)!='0777')$error .= ('Error 502: Wrong permissions for \'uploads/import\' (777 required)' . PHP_EOL);
 if (substr(sprintf('%o', @fileperms('../uploads/')), -4)!='0777')		$error .= ('Error 503: Wrong permissions for \'uploads/\' (777 required)' . PHP_EOL);
-if (substr(sprintf('%o', @fileperms('../data/')), -4)!='0777')			$error .= ('Error 504: Wrong permissions for \'data/\' (777 required)' . PHP_EOL);
+if (substr(sprintf('%o', @fileperms('../data/')), -4)!='0755')			$error .= ('Error 504: Wrong permissions for \'data/\' (777 required)' . PHP_EOL);
 
 if ($error=='') echo('Everything is fine. Lychee should work without problems!' . PHP_EOL . PHP_EOL); else echo $error;
 


### PR DESCRIPTION
Hello,
thx for your work - Lychee is very nice and I started to use it some weeks ago. In Version 2.1 (rc1 an prior?) die config.php is located in the data directory. Wenn I use the check.php the data directory schould be 0777. I think 0777 isn't the right permission for the data directory or at least the config.php (database login details) file? Could you please take a look, if this is correct ... maybe I've mixed things. What files will be located in the future under the data directory except config.php? Also all directories and files under uploads don't need 0777, I think. :)
