### PR TITLE
Duplicate albums on upload 

### DIFF
--- a/php/modules/album.php
+++ b/php/modules/album.php
@@ -193,6 +193,16 @@ function getAlbum($albumID) {
 
 }
 
+function getAlbumByTitle($title){
+
+		global $database;
+
+		$result = $database->query("SELECT id FROM lychee_albums WHERE title = '$title';");
+		$row = $result->fetch_object();
+
+		return ((isset($row->id) && is_numeric($row->id)) ? $row->id : false);
+}
+
 function setAlbumTitle($albumIDs, $title) {
 
 	global $database;

--- a/php/modules/db.php
+++ b/php/modules/db.php
@@ -102,7 +102,8 @@ function dbCreateTables($database) {
 			('thumbQuality','90'),
 			('checkForUpdates','1'),
 			('sorting','ORDER BY id DESC'),
-			('dropboxKey','');
+			('dropboxKey',''),
+			('albumPrefix', '[import] ');
 
 		";
 

--- a/php/modules/upload.php
+++ b/php/modules/upload.php
@@ -372,7 +372,7 @@ function importUrl($url, $albumID = 0) {
 
 function importServer($albumID = 0, $path = '../uploads/import/') {
 
-	global $database;
+	global $database, $settings;;
 
 	$files				= glob($path . '*');
 	$contains['photos'] = false;
@@ -388,10 +388,15 @@ function importServer($albumID = 0, $path = '../uploads/import/') {
 
 		} else if (is_dir($file)) {
 
-			$name		= mysqli_real_escape_string($database, basename($file));
-			$newAlbumID	= addAlbum('[Import] ' . $name);
 
-			if ($newAlbumID!==false) importServer($newAlbumID, $file . '/');
+			$name		= mysqli_real_escape_string($database, basename($file));
+
+			$albumID = getAlbumByTitle($settings['albumPrefix'] . $name);
+			
+			if($albumID == false)
+				$albumID	= addAlbum($settings['albumPrefix'] . $name);
+
+			if ($albumID!==false) importServer($albumID, $file . '/');
 			$contains['albums'] = true;
 
 		}


### PR DESCRIPTION
Added getAlbumByTitle function to merge albums on upload
Folder now merge if they are placed in folder that already has an album
Moved the albumPrefix form static to a setting in the db 

Note: This may require some more checking on duplicatie album name and placing an index on album title
