### PR TITLE
[Feature] don't hash passwords with MD5 in DB #114

### DIFF
--- a/php/database/update_020500.php
+++ b/php/database/update_020500.php
@@ -75,6 +75,10 @@ if (!$result) return false;
 $result = $database->query("ALTER TABLE `lychee_settings` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;");
 if (!$result) return false;
 
+# Set album password length to 100 (for longer hashes)
+$result = $database->query("ALTER TABLE `lychee_albums` CHANGE `password` `password` VARCHAR(100);");
+if (!$result) return false;
+
 # Set version
 $result = $database->query("UPDATE lychee_settings SET value = '020500' WHERE `key` = 'version';");
 if (!$result) return false;

--- a/php/modules/Album.php
+++ b/php/modules/Album.php
@@ -442,8 +442,16 @@ class Album extends Module {
 		# Call plugins
 		$this->plugins(__METHOD__, 0, func_get_args());
 
-		# Execute query
-		$result = $this->database->query("UPDATE lychee_albums SET password = '$password' WHERE id IN ('$this->albumIDs');");
+		if (isset($password)&&strlen($password)>0) {
+			# get hashed password
+			$password = get_hashed_password($password);
+
+			# set hashed password
+			$result = $this->database->query("UPDATE lychee_albums SET password = '$password' WHERE id IN ('$this->albumIDs');");
+		} else {
+			# unset password
+			$result = $this->database->query("UPDATE lychee_albums SET password = NULL WHERE id IN ('$this->albumIDs');");
+		}
 
 		# Call plugins
 		$this->plugins(__METHOD__, 1, func_get_args());
@@ -469,7 +477,7 @@ class Album extends Module {
 		$this->plugins(__METHOD__, 1, func_get_args());
 
 		if ($album->password=='') return true;
-		else if ($album->password===$password) return true;
+		else if ($album->password===$password||$album->password===crypt($password, $album->password)) return true;
 		return false;
 
 	}

--- a/php/modules/Session.php
+++ b/php/modules/Session.php
@@ -76,8 +76,14 @@ class Session extends Module {
 		# Call plugins
 		$this->plugins(__METHOD__, 0, func_get_args());
 
-		# Check login
+		# Check login with MD5 hash
 		if ($username===$this->settings['username']&&$password===$this->settings['password']) {
+			$_SESSION['login'] = true;
+			return true;
+		}
+
+		# Check login with crypted hash
+		if ($username===$this->settings['username']&&$this->settings['password']===crypt($password, $this->settings['password'])) {
 			$_SESSION['login'] = true;
 			return true;
 		}

--- a/php/modules/Settings.php
+++ b/php/modules/Settings.php
@@ -47,7 +47,7 @@ class Settings extends Module {
 		# Load settings
 		$settings = $this->get();
 
-		if ($oldPassword==$settings['password']) {
+		if ($oldPassword===$settings['password']||$settings['password']===crypt($oldPassword, $settings['password'])) {
 
 			# Save username
 			if (!$this->setUsername($username)) exit('Error: Updating username failed!');
@@ -85,7 +85,7 @@ class Settings extends Module {
 		# Check dependencies
 		$this->dependencies(isset($this->database));
 
-		if (strlen($password)<1||strlen($password)>50) return false;
+		$password = get_hashed_password($password);
 
 		# Execute query
 		$result = $this->database->query("UPDATE lychee_settings SET value = '$password' WHERE `key` = 'password';");

--- a/php/modules/misc.php
+++ b/php/modules/misc.php
@@ -80,4 +80,22 @@ function search($database, $settings, $term) {
 
 }
 
+function get_hashed_password($password) {
+
+	# inspired by -> http://alias.io/2010/01/store-passwords-safely-with-php-and-mysql/
+
+	# A higher "cost" is more secure but consumes more processing power
+	$cost = 10;
+
+	# Create a random salt
+	$salt = strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
+
+	# Prefix information about the hash so PHP knows how to verify it later.
+	# "$2a$" Means we're using the Blowfish algorithm. The following two digits are the cost parameter.
+	$salt = sprintf("$2a$%02d$", $cost) . $salt;
+
+	# Hash the password with the salt
+	return crypt($password, $salt);
+}
+
 ?>


### PR DESCRIPTION
All newly set and resetted passwords will now be stored as
blowfish hashed string generated via crypt().

Fixes: #114
