### PR TITLE
Added static declaration to Module::dependencies

### DIFF
--- a/php/modules/Module.php
+++ b/php/modules/Module.php
@@ -26,7 +26,7 @@ class Module {
 
 	}
 
-	public function dependencies($available = false) {
+	public static function dependencies($available = false) {
 
 		if ($available===false) exit('Error: Can not execute function. Missing parameters or variables.');
 


### PR DESCRIPTION
Dependencies under module was being called statically but it was not
statically declared. This throws warnings under strict PHP settings
which was causing the site to not load since the login check couldn't
function.

Adding the static declaration allows the site to work as expected.
