### PR TITLE
Larger text field for settings values

### DIFF
--- a/php/modules/db.php
+++ b/php/modules/db.php
@@ -86,7 +86,7 @@ function dbCreateTables($database) {
 
 			CREATE TABLE `lychee_settings` (
 				`key` varchar(50) NOT NULL DEFAULT '',
-				`value` varchar(50) DEFAULT ''
+				`value` varchar(200) DEFAULT ''
 			) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 		";


### PR DESCRIPTION
The `value` field in the settings table was too small for the value inserted when sorting photos by date taken: `'UNIX_TIMESTAMP(STR_TO_DATE(CONCAT(takedate,"-",taketime),"%d.%m.%Y-%H:%i:%S"))'`

Bumped the size up in the table creation query. The manual migration path for this is running this query:

``` sql
ALTER TABLE lychee_settings MODIFY COLUMN `value` VARCHAR(200);
```
