### PR TITLE
loosen perms for fpm

### DIFF
--- a/php/modules/misc.php
+++ b/php/modules/misc.php
@@ -120,6 +120,9 @@ function get_hashed_password($password) {
 
 function hasPermissions($path, $permissions = '0777') {
 
+	/* assume that if running with the same uid as the owner of the directory it's ok */
+	$stat = @stat($path);
+	if ($stat && ($stat['uid'] == getmyuid())) return true;
 	if (substr(sprintf('%o', @fileperms($path)), -4)!=$permissions) return false;
 	else return true;
 


### PR DESCRIPTION
By checking permissions of the target directory before uploading the pictures, you save yourself a lot of trouble. But asking for 777 is maybe too much in environments when php runs as the same user as the owner of the files (fastcgi, fpm, suexec, suphp, etc...), so here is a way to check this first
