### PR TITLE
Adding in photo checksum to detect dupes

### DIFF
--- a/php/database/update_020500.php
+++ b/php/database/update_020500.php
@@ -116,6 +116,15 @@ if (!$result) {
 	return false;
 }
 
+# Add `checksum`
+if (!$database->query("SELECT `checksum` FROM `lychee_photos` LIMIT 1;")) {
+	$result = $database->query("ALTER TABLE `lychee_photos` ADD `checksum` VARCHAR(100) DEFAULT NULL");
+	if (!$result) {
+		Log::error($database, 'update_020500', __LINE__, 'Could not update database (' . $database->error . ')');
+		return false;
+	}
+}
+
 # Reset sorting
 $result = $database->query("UPDATE lychee_settings SET value = 'ORDER BY takestamp DESC' WHERE `key` = 'sorting' AND `value` LIKE '%UNIX_TIMESTAMP%';");
 if (!$result) {

--- a/php/modules/Photo.php
+++ b/php/modules/Photo.php
@@ -130,7 +130,7 @@ class Photo extends Module {
 			}
 
 			# Save to DB
-			$query = "INSERT INTO lychee_photos (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star)
+			$query = "INSERT INTO lychee_photos (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum)
 				VALUES (
 					'" . $id . "',
 					'" . $info['title'] . "',
@@ -151,7 +151,8 @@ class Photo extends Module {
 					'" . md5($id) . ".jpeg',
 					'" . $albumID . "',
 					'" . $public . "',
-					'" . $star . "');";
+					'" . $star . "',
+					'" . md5_file($path) . "');";
 			$result = $this->database->query($query);
 
 			if (!$result) {


### PR DESCRIPTION
Storing an MD5 checksum of each photo uploaded.  Could be used to detect duplicates of files.
