### PR TITLE
Fix the issue that search function will return all photos

### DIFF
--- a/php/modules/misc.php
+++ b/php/modules/misc.php
@@ -16,7 +16,7 @@ function search($database, $settings, $term) {
 	$return['albums'] = '';
 
 	// Photos
-	$query	= Database::prepare($database, "SELECT id, title, tags, public, star, album, thumbUrl FROM ? WHERE title LIKE '%?%' OR description LIKE '%%' OR tags LIKE '%?%'", array(LYCHEE_TABLE_PHOTOS, $term, $term, $term));
+	$query	= Database::prepare($database, "SELECT id, title, tags, public, star, album, thumbUrl FROM ? WHERE title LIKE '%?%' OR description LIKE '%?%' OR tags LIKE '%?%'", array(LYCHEE_TABLE_PHOTOS, $term, $term, $term));
 	$result	= $database->query($query);
 	while($row = $result->fetch_assoc()) {
 		$return['photos'][$row['id']]				= $row;


### PR DESCRIPTION
That line of code will match every description whatever your search term is.
And this is probably not what we want.

This pull request will help fix this missing "?" on query photos from description.
