### PR TITLE
Fix the position of button_settings context menu if the user move scroll bar on mobile device

### DIFF
--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -18,7 +18,7 @@ $(document).ready(function(){
 	/* Header */
 	$("#hostedwith").on(event_name, function() { window.open(lychee.website) });
 	$("#button_signin").on(event_name, lychee.loginDialog);
-	$("#button_settings").on("click", contextMenu.settings);
+	$("#button_settings").on(event_name, contextMenu.settings);
 	$("#button_share").on(event_name, function(e) {
 		if (photo.json.public==1||photo.json.public==2) contextMenu.sharePhoto(photo.getID(), e);
 		else photo.setPublic(photo.getID(), e);


### PR DESCRIPTION
As titled, note that please apply https://github.com/electerious/basicContext/pull/5 for basicContext first to ensure the context menu item will not be triggered right after showing context menu.
