### PR TITLE
Added import event

### DIFF
--- a/php/modules/Import.php
+++ b/php/modules/Import.php
@@ -82,6 +82,8 @@ class Import extends Module {
 		$contains['photos']	= false;
 		$contains['albums']	= false;
 
+		$plugins->activate(__METHOD__ . ":before", array($albumID, $path));
+
 		# Get all files
 		$files = glob($path . '/*');
 
@@ -132,6 +134,8 @@ class Import extends Module {
 			}
 
 		}
+
+		$plugins->activate(__METHOD__ . ":after", array($albumID, $path));
 
 		if ($contains['photos']===false&&$contains['albums']===false)	return 'Warning: Folder empty or no readable files to process!';
 		if ($contains['photos']===false&&$contains['albums']===true)	return 'Notice: Import only contains albums!';

--- a/php/modules/Import.php
+++ b/php/modules/Import.php
@@ -107,7 +107,6 @@ class Import extends Module {
 					continue;
 				}
 				$contains['photos'] = true;
-				unlink($file);
 
 			} else if (is_dir($file)) {
 

--- a/php/modules/Import.php
+++ b/php/modules/Import.php
@@ -107,6 +107,7 @@ class Import extends Module {
 					continue;
 				}
 				$contains['photos'] = true;
+				unlink($file);
 
 			} else if (is_dir($file)) {
 

--- a/php/modules/Import.php
+++ b/php/modules/Import.php
@@ -82,6 +82,9 @@ class Import extends Module {
 		$contains['photos']	= false;
 		$contains['albums']	= false;
 
+		# Invoke plugins directly, as instance method not valid here
+		# Note that updated albumId and path explicitly passed, rather
+		# than using func_get_args() which will only return original ones
 		$plugins->activate(__METHOD__ . ":before", array($albumID, $path));
 
 		# Get all files
@@ -135,6 +138,9 @@ class Import extends Module {
 
 		}
 
+		# Invoke plugins directly, as instance method not valid here
+		# Note that updated albumId and path explicitly passed, rather
+		# than using func_get_args() which will only return original ones
 		$plugins->activate(__METHOD__ . ":after", array($albumID, $path));
 
 		if ($contains['photos']===false&&$contains['albums']===false)	return 'Warning: Folder empty or no readable files to process!';

--- a/plugins/check/index.php
+++ b/plugins/check/index.php
@@ -115,5 +115,6 @@ echo('Imagick:         ' . $imagick . PHP_EOL);
 echo('Imagick Active:  ' . $settings['imagick'] . PHP_EOL);
 echo('Imagick Version: ' . $imagickVersion . PHP_EOL);
 echo('GD Version:      ' . $gdVersion['GD Version'] . PHP_EOL);
+echo('Plugins:         ' . $settings['plugins'] . PHP_EOL);
 
 ?>


### PR DESCRIPTION
Hi,

I've written a simple import plugin [here](https://github.com/mhp/Lychee-FlashAir) and to make it work, I needed to add an event to the server import logic.  Here is that change, along with two other minor tweaks I needed: delete files on import, and show current plugins.

Feel free to take none, some, or all of these changes if you think they are helpful!  I think they will apply to either `master` or `v3.0.0` branches, but I have tested against `master`.