### PR TITLE
Implement Natural Sorting for the Title

### DIFF
--- a/php/modules/Settings.php
+++ b/php/modules/Settings.php
@@ -143,7 +143,7 @@ class Settings extends Module {
 			case 'id':			$sorting .= 'id';
 								break;
 
-			case 'title':		$sorting .= 'title';
+			case 'title':		$sorting .= 'LENGTH(title), title';
 								break;
 
 			case 'description':	$sorting .= 'description';


### PR DESCRIPTION
The Problem is if im sorting the Pics according the Title and i have a number in the title the sorting is not working well.

For example in following query the first three pics are Babyshooting_Miro1, Babyshooting_Miro10, Babyshooting_Miro11.

mysql> SELECT id, title, CONVERT(title, DECIMAL) FROM lychee_photos WHERE title LIKE '%Miro%' ORDER BY title;
+----------------+---------------------+-------------------------+
| id             | title               | CONVERT(title, DECIMAL) |
+----------------+---------------------+-------------------------+
| 14275576167600 | Babyshooting_Miro1  |                       0 |
| 14275576308400 | Babyshooting_Miro10 |                       0 |
| 14275576329300 | Babyshooting_Miro11 |                       0 |
| 14275576180000 | Babyshooting_Miro2  |                       0 |
+----------------+---------------------+-------------------------+

To fix the problem I have extended the SQL query as follows.

mysql> SELECT id, title, CONVERT(title, DECIMAL) FROM lychee_photos WHERE title LIKE '%Miro%' ORDER BY LENGTH(title), title;
+----------------+---------------------+-------------------------+
| id             | title               | CONVERT(title, DECIMAL) |
+----------------+---------------------+-------------------------+
| 14275576167600 | Babyshooting_Miro1  |                       0 |
| 14275576180000 | Babyshooting_Miro2  |                       0 |
| 14275576205800 | Babyshooting_Miro3  |                       0 |
| 14275576206300 | Babyshooting_Miro4  |                       0 |
+----------------+---------------------+-------------------------+