### PR TITLE
Allow Album sorting

### DIFF
--- a/php/modules/Album.php
+++ b/php/modules/Album.php
@@ -189,8 +189,8 @@ class Album extends Module {
 		if ($public===false) $return['smartalbums'] = $this->getSmartInfo();
 
 		# Albums query
-		$query = Database::prepare($this->database, 'SELECT id, title, public, sysstamp, password FROM ? WHERE public = 1 AND visible <> 0', array(LYCHEE_TABLE_ALBUMS));
-		if ($public===false) $query = Database::prepare($this->database, 'SELECT id, title, public, sysstamp, password FROM ?', array(LYCHEE_TABLE_ALBUMS));
+		$query = Database::prepare($this->database, 'SELECT id, title, public, sysstamp, password FROM ? WHERE public = 1 AND visible <> 0 ' . $this->settings['sorting'], array(LYCHEE_TABLE_ALBUMS));
+		if ($public===false) $query = Database::prepare($this->database, 'SELECT id, title, public, sysstamp, password FROM ? ' . $this->settings['sorting'], array(LYCHEE_TABLE_ALBUMS));
 
 		# Execute query
 		$albums = $this->database->query($query);
@@ -223,7 +223,7 @@ class Album extends Module {
 			}
 
 			# Add to return
-			$return['albums'][$album['id']] = $album;
+			$return['albums'][] = $album;
 
 		}
 


### PR DESCRIPTION
A real array index stops json touch the sorting 
References #98

Needs to revert the array reverse view in https://github.com/electerious/Lychee/blob/release/v3.0.0/src/scripts/view.js#L51
and "_maybe?_" as well in https://github.com/electerious/Lychee/blob/release/v3.0.0/src/scripts/view.js#L55

I have a weird follow-up issue here, that some (last) albums do not open up on click (throwing an error), but do work well right after, on keyboard reload (F5 or CTRL-R)... I don't know why!