### PR TITLE
Added session cookie

### DIFF
--- a/php/access/Admin.php
+++ b/php/access/Admin.php
@@ -253,7 +253,7 @@ class Admin extends Access {
 
 	private function login() {
 
-                global $dbName;
+		global $dbName;
 
 		Module::dependencies(isset($_POST['user'], $_POST['password']));
 		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
@@ -263,7 +263,7 @@ class Admin extends Access {
 
 	private function logout() {
 
-                global $dbName;
+		global $dbName;
 
 		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->logout();

--- a/php/access/Admin.php
+++ b/php/access/Admin.php
@@ -246,22 +246,26 @@ class Admin extends Access {
 		global $dbName;
 
 		Module::dependencies(isset($_POST['version']));
-		$session = new Session($this->plugins, $this->settings);
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo json_encode($session->init($this->database, $dbName, false, $_POST['version']));
 
 	}
 
 	private function login() {
 
+                global $dbName;
+
 		Module::dependencies(isset($_POST['user'], $_POST['password']));
-		$session = new Session($this->plugins, $this->settings);
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->login($_POST['user'], $_POST['password']);
 
 	}
 
 	private function logout() {
 
-		$session = new Session($this->plugins, $this->settings);
+                global $dbName;
+
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->logout();
 
 	}

--- a/php/access/Guest.php
+++ b/php/access/Guest.php
@@ -118,7 +118,7 @@ class Guest extends Access {
 
 	private function login() {
 
-                global $dbName;
+		global $dbName;
 
 		Module::dependencies(isset($_POST['user'], $_POST['password']));
 		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
@@ -128,7 +128,7 @@ class Guest extends Access {
 
 	private function logout() {
 
-                global $dbName;
+		global $dbName;
 
 		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->logout();

--- a/php/access/Guest.php
+++ b/php/access/Guest.php
@@ -111,22 +111,26 @@ class Guest extends Access {
 
 		global $dbName;
 
-		$session = new Session($this->plugins, $this->settings);
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo json_encode($session->init($this->database, $dbName, true, $_POST['version']));
 
 	}
 
 	private function login() {
 
+                global $dbName;
+
 		Module::dependencies(isset($_POST['user'], $_POST['password']));
-		$session = new Session($this->plugins, $this->settings);
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->login($_POST['user'], $_POST['password']);
 
 	}
 
 	private function logout() {
 
-		$session = new Session($this->plugins, $this->settings);
+                global $dbName;
+
+		$session = new Session($this->database, $dbName, $this->plugins, $this->settings);
 		echo $session->logout();
 
 	}

--- a/php/database/sessions_table.sql
+++ b/php/database/sessions_table.sql
@@ -1,0 +1,12 @@
+# Dump of table lychee_sessions
+# ------------------------------------------------------------
+--
+-- Table structure for table `lychee_sessions`
+--
+
+DROP TABLE IF EXISTS `lychee_sessions`;
+CREATE TABLE `lychee_sessions` (
+      `value` varchar(40) DEFAULT NULL,
+      `expires` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/php/database/settings_content.sql
+++ b/php/database/settings_content.sql
@@ -16,3 +16,4 @@ VALUES
   ('dropboxKey',''),
   ('identifier',''),
   ('plugins','');
+  ('sessionLength','1440');

--- a/php/define.php
+++ b/php/define.php
@@ -47,6 +47,7 @@ function defineTablePrefix($dbTablePrefix) {
 	define('LYCHEE_TABLE_LOG', $dbTablePrefix . 'lychee_log');
 	define('LYCHEE_TABLE_PHOTOS', $dbTablePrefix . 'lychee_photos');
 	define('LYCHEE_TABLE_SETTINGS', $dbTablePrefix . 'lychee_settings');
+	define('LYCHEE_TABLE_SESSIONS', $dbTablePrefix . 'lychee_sessions');
 
 }
 

--- a/php/modules/Database.php
+++ b/php/modules/Database.php
@@ -31,7 +31,7 @@ class Database extends Module {
 			if (!Database::createDatabase($database, $name)) exit('Error: Could not create database!');
 
 		# Check tables
-		$query = Database::prepare($database, 'SELECT * FROM ?, ?, ?, ? LIMIT 0', array(LYCHEE_TABLE_PHOTOS, LYCHEE_TABLE_ALBUMS, LYCHEE_TABLE_SETTINGS, LYCHEE_TABLE_LOG));
+		$query = Database::prepare($database, 'SELECT * FROM ?, ?, ?, ? LIMIT 0', array(LYCHEE_TABLE_PHOTOS, LYCHEE_TABLE_ALBUMS, LYCHEE_TABLE_SETTINGS, LYCHEE_TABLE_LOG, LYCHEE_TABLE_SESSIONS));
 		if (!$database->query($query))
 			if (!Database::createTables($database)) exit('Error: Could not create tables!');
 

--- a/php/modules/Session.php
+++ b/php/modules/Session.php
@@ -16,8 +16,8 @@ class Session extends Module {
 		# Init vars
 		$this->plugins	= $plugins;
 		$this->settings	= $settings;
-                $this->database = $database;
-                $this->dbname   = $dbname;
+		$this->database = $database;
+		$this->dbname	= $dbname;
 
 		return true;
 
@@ -39,9 +39,9 @@ class Session extends Module {
 			}
 		}
 
-                # Clear expired sessions
-                $query = Database::prepare($this->database, "DELETE FROM ? WHERE expires < UNIX_TIMESTAMP(NOW())", array(LYCHEE_TABLE_SESSIONS));
-                $this->database->query($query);
+		# Clear expired sessions
+		$query = Database::prepare($this->database, "DELETE FROM ? WHERE expires < UNIX_TIMESTAMP(NOW())", array(LYCHEE_TABLE_SESSIONS));
+		$this->database->query($query);
 
 		# Return settings
 		$return['config'] = $this->settings;
@@ -65,11 +65,11 @@ class Session extends Module {
 		}
 
 		# Check login with crypted hash
-                if(isset( $_COOKIE['SESSION']) && $this->sessionExists($_COOKIE['SESSION']) ){
-                      	$_SESSION['login']		= true;
+		if(isset( $_COOKIE['SESSION']) && $this->sessionExists($_COOKIE['SESSION']) ){
+			$_SESSION['login']		= true;
 			$_SESSION['identifier']	= $this->settings['identifier'];
-                        $public = false;
-                }
+			$public = false;
+		}
  
 		if ($public===false) {
 
@@ -112,17 +112,17 @@ class Session extends Module {
 		$username = crypt($username, $this->settings['username']);
 		$password = crypt($password, $this->settings['password']);
 
-                if ($this->settings['username']===$username&&
+		if ($this->settings['username']===$username&&
 			$this->settings['password']===$password) {
 				$_SESSION['login']		= true;
 				$_SESSION['identifier']	= $this->settings['identifier'];
 
-                                $expire = time() + 60 * $this->settings['sessionLength'];
-                                $hash = hash("sha1", $expire.$this->settings['identifier'].$this->settings['username'].$this->settings['password']);
-                                $query = Database::prepare($this->database, "INSERT INTO ? (value, expires) VALUES ('?', ?)", array(LYCHEE_TABLE_SESSIONS, $hash, $expire));
-                                $result = $this->database->query($query);
+				$expire = time() + 60 * $this->settings['sessionLength'];
+				$hash = hash("sha1", $expire.$this->settings['identifier'].$this->settings['username'].$this->settings['password']);
+				$query = Database::prepare($this->database, "INSERT INTO ? (value, expires) VALUES ('?', ?)", array(LYCHEE_TABLE_SESSIONS, $hash, $expire));
+				$result = $this->database->query($query);
 
-                                setcookie("SESSION", $hash, $expire, "/","", false, true);
+				setcookie("SESSION", $hash, $expire, "/","", false, true);
 
 				return true;
 		}
@@ -143,7 +143,7 @@ class Session extends Module {
 		self::dependencies(isset($this->settings));
 
 		# Check if login credentials exist and login if they don't
-                if($this->settings['username']==='' && $this->settings['password']==='') {
+		if($this->settings['username']==='' && $this->settings['password']==='') {
 				$_SESSION['login']		= true;
 				$_SESSION['identifier']	= $this->settings['identifier'];
 				return true;
@@ -161,11 +161,11 @@ class Session extends Module {
 		$_SESSION['login']		= null;
 		$_SESSION['identifier']	= null;
 
-                # Delete the session from the database
-                if(isset($_COOKIE['SESSION'])){
-                  $query = Database::prepare($this->database, "DELETE FROM ? WHERE value = '?'", array(LYCHEE_TABLE_SESSIONS, $_COOKIE['SESSION']));
-                  $this->database->query($query);
-                }
+		# Delete the session from the database
+		if(isset($_COOKIE['SESSION'])){
+		  $query = Database::prepare($this->database, "DELETE FROM ? WHERE value = '?'", array(LYCHEE_TABLE_SESSIONS, $_COOKIE['SESSION']));
+		  $this->database->query($query);
+		}
 
 		session_destroy();
 
@@ -174,13 +174,13 @@ class Session extends Module {
 
 		return true;
 
-        }
+	}
 
-        private function sessionExists($sessionId){
-              $query = Database::prepare($this->database, "SELECT * FROM ? WHERE value = '?'", array(LYCHEE_TABLE_SESSIONS, $sessionId));
-              $result = $this->database->query($query);
-              return $result->num_rows === 1;
-        }
+	private function sessionExists($sessionId){
+	      $query = Database::prepare($this->database, "SELECT * FROM ? WHERE value = '?'", array(LYCHEE_TABLE_SESSIONS, $sessionId));
+	      $result = $this->database->query($query);
+	      return $result->num_rows === 1;
+	}
 
 }
 


### PR DESCRIPTION
Creates a new table, lychee_sessions, in which a sha1-hash and a timestamp is stored for each session. The hash is stored in a cookie on the client-side, SESSION, on the client and allows a user to stay signed in for longer than the php session. The hash is a combination of the expiry timestamp, the username hash, the passwordhash and the identifier.

The session length is specified in minutes in the settings table.

My reason for implementing this is that I go to my lychee sites multiple times every day, and having to log in every time is just a bit annoying. With this change I can stay logged in for as long as I want.
