### PR TITLE
Use src/ instead of build/ directory

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -9,9 +9,9 @@ First you have to install the following dependencies:
 
 After [installing Node.js](http://nodejs.org) you can use the included `npm` package manager to install the global requirements and Lychee-dependencies with the following command:
 
-	cd build/;
-	npm install -g bower gulp;
-	npm install && bower install;
+	cd src/
+	npm install -g bower gulp
+	npm install && bower install
 
 ### Build
 


### PR DESCRIPTION
The dependency file package.json is in src/ so npm install should be run from there.

Also remove the extra ";" at the end of line. This is shell code, not JavaScript.