### PR TITLE
A proposed solution to #421 and #420, to make turning logs public or private trivial even when Lychee fails to work.

### DIFF
--- a/plugins/check/.htaccess
+++ b/plugins/check/.htaccess
@@ -1,0 +1,5 @@
+Order deny,allow
+Deny from all
+Allow from localhost
+Allow from 127.0.0.1
+Allow from ::1

--- a/plugins/displaylog/.htaccess
+++ b/plugins/displaylog/.htaccess
@@ -1,0 +1,5 @@
+Order deny,allow
+Deny from all
+Allow from localhost
+Allow from 127.0.0.1
+Allow from ::1


### PR DESCRIPTION
Add a .htaccess restricting access to localhost by default to the check and displaylog plugins, to avoid revealing sensitive information without knowing (see issues #421 and #420)