### PR TITLE
Various fixes for php 32bits and long albums/photos ids

### DIFF
--- a/php/Modules/Response.php
+++ b/php/Modules/Response.php
@@ -16,10 +16,9 @@ final class Response {
 
 	}
 
-	public static function json($str) {
-
-		exit(json_encode($str));
-
+	// JSON_NUMERIC_CHECK ensure the albums/photos ids will be converted from strings to integers
+	public static function json($str, $options = JSON_NUMERIC_CHECK) { 
+		exit(json_encode($str, $options));
 	}
 
 }

--- a/php/helpers/generateID.php
+++ b/php/helpers/generateID.php
@@ -8,8 +8,8 @@ function generateID() {
 	// Ensure that the id has a length of 14 chars
 	while(strlen($id)<14) $id .= 0;
 
-	// Return the integer value of the id
-	return intval($id);
+	// Return id as a string (32bit php can't handle 14digit integers)
+	return $id;
 
 }
 


### PR DESCRIPTION
(love your project btw)
The ids have to be integers as this is what the javascript part expect. (When creating an album for instance.)

edit:
Just realized it breaks staring photos. "0"s & "1"s are passed through json to javascript.
I'll look into it soon.

edit2:
On an other topic, using "prerender" instead of "prefetch" decrease considerably the time needed to show the next/previous photo.