### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Lychee is a free photo-management tool, which runs on your server or web-space. 
 
 To run Lychee, everything you need is a web-server with PHP 5.5 or later and a MySQL-Database. Follow the instructions to install Lychee on your server. [Installation &#187;](docs/Installation.md)
 
+## Nitrous Quickstart
+
+Create a free development environment for this Lychee project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply access your site via the `Preview > 3000` link in the IDE.
+
 ## How to use
 
 You can use Lychee right after the installation. Here are some advanced features to get the most out of it.

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,9 @@
+# Setup
+
+Welcome to your Lychee project on Nitrous.
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "php-apache",
+  "ports": [3000],
+  "name": "Lychee",
+  "description": "A great looking and easy-to-use photo-management-system you can run on your server, to manage and share photos.",
+  "scripts": {
+    "post-create": "rm -rf ~/code/public_html && cd ~/code && mv Lychee public_html && sudo chown -R nitrous:www-data public_html && sudo chmod -R g+w public_html && cd public_html && sudo chmod -R 777 uploads/ data/"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.