### PR TITLE
Improved fullscreen enter/leave in photo view.

### DIFF
--- a/src/scripts/header.js
+++ b/src/scripts/header.js
@@ -67,8 +67,6 @@ header.bind = function() {
 
 header.show = function() {
 
-	clearTimeout($(window).data('timeout'))
-
 	lychee.imageview.removeClass('full')
 	header.dom().removeClass('header--hidden')
 
@@ -76,18 +74,12 @@ header.show = function() {
 
 }
 
-header.hide = function(e, delay = 500) {
+header.hide = function(e) {
 
 	if (visible.photo() && !visible.sidebar() && !visible.contextMenu() && basicModal.visible()===false) {
 
-		clearTimeout($(window).data('timeout'))
-
-		$(window).data('timeout', setTimeout(function() {
-
-			lychee.imageview.addClass('full')
-			header.dom().addClass('header--hidden')
-
-		}, delay))
+		lychee.imageview.addClass('full')
+		header.dom().addClass('header--hidden')
 
 		return true
 

--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -80,7 +80,7 @@ $(document).ready(function() {
 			// Fullscreen on mobile
 			.on('touchend', '#imageview #image', function(e) {
 				if (swipe.obj==null || (swipe.offset>=-5&&swipe.offset<=5)) {
-					if (visible.header()) header.hide(e, 0)
+					if (visible.header()) header.hide(e)
 					else                  header.show()
 				}
 			})

--- a/src/scripts/multiselect.js
+++ b/src/scripts/multiselect.js
@@ -159,7 +159,7 @@ multiselect.resize = function(e) {
 
 multiselect.stopResize = function() {
 
-	$(document).off('mousemove mouseup')
+	if (multiselect.position.top!==null) $(document).off('mousemove mouseup')
 
 }
 

--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -313,7 +313,7 @@ view.photo = {
 		$(document).bind('mousemove', function() {
 			clearTimeout(timeout)
 			header.show()
-			timeout = setTimeout(header.hide, 500)
+			timeout = setTimeout(header.hide, 1000)
 		})
 
 		lychee.animate(lychee.imageview, 'fadeIn')

--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -309,9 +309,12 @@ view.photo = {
 		$('body').css('overflow', 'hidden')
 
 		// Fullscreen
-		$(document)
-			.bind('mouseenter', header.show)
-			.bind('mouseleave', header.hide)
+		var timeout
+		$(document).bind('mousemove', function() {
+			clearTimeout(timeout)
+			header.show()
+			timeout = setTimeout(header.hide, 500)
+		})
 
 		lychee.animate(lychee.imageview, 'fadeIn')
 
@@ -329,8 +332,7 @@ view.photo = {
 
 		// Disable Fullscreen
 		$(document)
-			.unbind('mouseenter')
-			.unbind('mouseleave')
+			.unbind('mousemove')
 
 		// Hide Photo
 		lychee.animate(lychee.imageview, 'fadeOut')


### PR DESCRIPTION
Previously, document.mouse{enter,leave} was used for that. This
has the disadvantage that is doesn't work when the browser is
in fullscreen mode (at least, in Chromium), because the mouse
can no longer leave the document.

With this commit, mousemove is used to switch to fullscreen
in the photo view after the user has not moved the mouse for
some time. It is left again, if the user moves the mouse.