### PR TITLE
Added warning if Imagick is not installed/enabled.

### DIFF
--- a/plugins/Diagnostics/index.php
+++ b/plugins/Diagnostics/index.php
@@ -99,6 +99,10 @@ if (empty(ini_get('allow_url_fopen'))) echo('Warning: You may experience problem
 // Check mysql version
 if ($database->server_version<50500) echo('Warning: Lychee uses the GBK charset to avoid sql injections on your MySQL version. Please update to MySQL 5.5 or higher to enable UTF-8 support.' . PHP_EOL);
 
+// Check imagick
+if (!extension_loaded('imagick')) echo('Warning: Pictures that are rotated lose their metadata! Please install Imagick to avoid that.' . PHP_EOL);
+else if (!$settings['imagick']) echo('Warning: Pictures that are rotated lose their metadata! Please enable Imagick in settings to avoid that.' . PHP_EOL);
+
 // Output
 if ($error==='') echo('No critical problems found. Lychee should work without problems!' . PHP_EOL);
 else             echo $error;


### PR DESCRIPTION
If GD is used instead of Imagick, rotating uploaded pictures leads to
a loss of their metadata. Since this is unexpected and maybe a problem,
the diagnostics should show a warning.

This commit displays a warning if it's either not installed or not
enabled in settings.

Maybe, rotating pictures etc. should even be optional in case the user
can't install imagick and still doesn't want to lose the metadata?