### PR TITLE
Redirect to start page if we were logged out.

### DIFF
--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -34,9 +34,40 @@ final class Guest extends Access {
 			case 'Album::getArchive': self::getAlbumArchiveAction(); break;
 			case 'Photo::getArchive': self::getPhotoArchiveAction(); break;
 
+			// Admin functions
+			case 'Album::add':
+			case 'Album::setTitle':
+			case 'Album::setDescription':
+			case 'Album::setPublic':
+			case 'Album::delete':
+			case 'Album::merge':
+			case 'Photo::setTitle':
+			case 'Photo::setDescription':
+			case 'Photo::setStar':
+			case 'Photo::setPublic':
+			case 'Photo::setAlbum':
+			case 'Photo::setTags':
+			case 'Photo::duplicate':
+			case 'Photo::delete':
+			case 'Photo::add':
+			case 'Import::url':
+			case 'Import::server':
+			case 'search':
+			case 'Settings::setLogin':
+			case 'Settings::setSorting':
+			case 'Settings::setDropboxKey':
+				self::adminAction();
+				break;
+
 		}
 
 		self::fnNotFound();
+
+	}
+
+	private static function adminAction() {
+
+		Response::error('Function not available for guests.');
 
 	}
 

--- a/src/scripts/album.js
+++ b/src/scripts/album.js
@@ -49,6 +49,12 @@ album.load = function(albumID, refresh = false) {
 
 			if (data==='Warning: Album private!') {
 
+				// if we were in private mode, restart lychee. maybe the cookie has expired
+				if (!lychee.publicMode) {
+					lychee.restart()
+					return false
+				}
+
 				if (document.location.hash.replace('#', '').split('/')[1]!=undefined) {
 					// Display photo only
 					lychee.setMode('view')

--- a/src/scripts/lychee.js
+++ b/src/scripts/lychee.js
@@ -425,7 +425,7 @@ lychee.html = function(literalSections, ...substs) {
 lychee.error = function(errorThrown, params, data) {
 
 	// in this case, our cookie has probably expired
-	if (data.startsWith('Error: Function not available for guests.')) {
+	if (data==='Error: Function not available for guests.') {
 		lychee.restart()
 		return
 	}

--- a/src/scripts/lychee.js
+++ b/src/scripts/lychee.js
@@ -424,8 +424,8 @@ lychee.html = function(literalSections, ...substs) {
 
 lychee.error = function(errorThrown, params, data) {
 
-	// if the requested function was not found, our cookie has probably expired
-	if (data.startsWith('Error: Function not found!')) {
+	// in this case, our cookie has probably expired
+	if (data.startsWith('Error: Function not available for guests.')) {
 		lychee.restart()
 		return
 	}

--- a/src/scripts/lychee.js
+++ b/src/scripts/lychee.js
@@ -144,6 +144,12 @@ lychee.logout = function() {
 
 }
 
+lychee.restart = function() {
+
+	document.location.href = ''
+
+}
+
 lychee.goto = function(url = '') {
 
 	url = '#' + url
@@ -417,6 +423,12 @@ lychee.html = function(literalSections, ...substs) {
 }
 
 lychee.error = function(errorThrown, params, data) {
+
+	// if the requested function was not found, our cookie has probably expired
+	if (data.startsWith('Error: Function not found!')) {
+		lychee.restart()
+		return
+	}
 
 	console.error({
 		description : errorThrown,

--- a/src/scripts/photo.js
+++ b/src/scripts/photo.js
@@ -48,9 +48,17 @@ photo.load = function(photoID, albumID) {
 	api.post('Photo::get', params, function(data) {
 
 		if (data==='Warning: Photo private!') {
+
+			// if we were in private mode, restart lychee. maybe the cookie has expired
+			if (!lychee.publicMode) {
+				lychee.restart()
+				return false
+			}
+
 			lychee.content.show()
 			lychee.goto()
 			return false
+
 		}
 
 		if (data==='Warning: Wrong password!') {


### PR DESCRIPTION
Previously, Lychee simply stopped working if, e.g., our cookie
expired without letting the user know what went wrong. Now, the user
gets redirected to the start page instead.

This happens if:
1. viewing a private album/photo is denied in private mode
2. the requested function on the server is not available for guests
