### PR TITLE
Allowed Albums with only Sub albums to show a thumbnail

### DIFF
--- a/php/Modules/Album.php
+++ b/php/Modules/Album.php
@@ -475,26 +475,27 @@ final class Album {
 
 	}
 
-	private function getSubAlbums($albumID) {
+	public static function getSubAlbums($albumID) {
 
 		$query = Database::prepare(Database::get(), "SELECT id FROM ? WHERE parent = '?'", array(LYCHEE_TABLE_ALBUMS, $albumID));
 		$albums = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
 		$ids = array();
 		while($album = $albums->fetch_assoc()) {
-			$ids = array_merge($ids, array($album['id']), $this->getSubAlbums($album['id']));
+			$ids = array_merge($ids, array($album['id']), self::getSubAlbums($album['id']));
 		}
 
 		return $ids;
 
 	}
 
-	private function addSubAlbumIDs($ids) {
+
+	public static function addSubAlbumIDs($ids) {
 
 		$res = array();
 
 		foreach(explode(',', $ids) as $id)
-			$res = array_merge($res, array($id), $this->getSubAlbums($id));
+			$res = array_merge($res, array($id), self::getSubAlbums($id));
 
 		return implode(',', $res);
 

--- a/php/Modules/Albums.php
+++ b/php/Modules/Albums.php
@@ -51,7 +51,7 @@ final class Albums {
 				($public===false)) {
 
 					// Execute query
-					$query  = Database::prepare(Database::get(), "SELECT thumbUrl FROM ? WHERE album = '?' ORDER BY star DESC, " . substr(Settings::get()['sortingPhotos'], 9) . " LIMIT 3", array(LYCHEE_TABLE_PHOTOS, $album['id']));
+					$query  = Database::prepare(Database::get(), "SELECT thumbUrl FROM ? WHERE album IN (?) ORDER BY star DESC, " . substr(Settings::get()['sortingPhotos'], 9) . " LIMIT 3", array(LYCHEE_TABLE_PHOTOS, Album::addSubAlbumIDs($album['id'])));
 					$thumbs = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
 					if ($thumbs===false) return false;


### PR DESCRIPTION
This allows an album with no pictures that contains subalbums with pictures to still have a thumbnail.

# Changes
1. Album.php functions getSubAlbums and addSubAlbumIds to static to allow better access from Albums.php. 
2. The thumbnail query has been changed to get the output of AddSubAlbumIds and use it in an "IN" SQL function

# Result

In a structure as follows:
- Main Album
  - Sub1
    - Sub2
      - Pic2.jpg
     - Pic1.jpg

Main Album will have Pic1 and Pic2 in its thumbs list as will Sub1. Sub2 will only have Pic2.
