### PR TITLE
Full Screen and Social Sharing Options for Albums

### DIFF
--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -117,10 +117,10 @@ final class Admin extends Access {
 
 	private static function setAlbumPublicAction() {
 
-		Validator::required(isset($_POST['albumID'], $_POST['password'], $_POST['visible'], $_POST['downloadable']), __METHOD__);
+		Validator::required(isset($_POST['albumID'], $_POST['password'], $_POST['visible'], $_POST['downloadable'], $_POST['fullscreen'], $_POST['shareable']),  __METHOD__);
 
 		$album = new Album($_POST['albumID']);
-		Response::json($album->setPublic($_POST['public'], $_POST['password'], $_POST['visible'], $_POST['downloadable']));
+		Response::json($album->setPublic($_POST['public'], $_POST['password'], $_POST['visible'], $_POST['downloadable'], $_POST['fullscreen'], $_POST['shareable']));
 
 	}
 

--- a/php/Modules/Album.php
+++ b/php/Modules/Album.php
@@ -69,6 +69,8 @@ final class Album {
 		if (isset($data['description']))  $album['description'] = $data['description'];
 		if (isset($data['visible']))      $album['visible'] = $data['visible'];
 		if (isset($data['downloadable'])) $album['downloadable'] = $data['downloadable'];
+		if (isset($data['fullscreen']))   $album['fullscreen'] = $data['fullscreen'];
+		if (isset($data['shareable']))    $album['shareable'] = $data['shareable'];
 
 		// Parse date
 		$album['sysdate'] = strftime('%B %Y', $data['sysstamp']);
@@ -444,7 +446,7 @@ final class Album {
 	/**
 	 * @return boolean Returns true when successful.
 	 */
-	public function setPublic($public, $password, $visible, $downloadable) {
+	public function setPublic($public, $password, $visible, $downloadable, $fullscreen, $shareable) {
 
 		// Check dependencies
 		Validator::required(isset($this->albumIDs), __METHOD__);
@@ -456,9 +458,11 @@ final class Album {
 		$public       = ($public==='1' ? 1 : 0);
 		$visible      = ($visible==='1' ? 1 : 0);
 		$downloadable = ($downloadable==='1' ? 1 : 0);
+		$fullscreen   = ($fullscreen==='1' ? 1 : 0);
+		$shareable    = ($shareable==='1' ? 1 : 0);
 
 		// Set public
-		$query  = Database::prepare(Database::get(), "UPDATE ? SET public = '?', visible = '?', downloadable = '?', password = NULL WHERE id IN (?)", array(LYCHEE_TABLE_ALBUMS, $public, $visible, $downloadable, $this->albumIDs));
+		$query  = Database::prepare(Database::get(), "UPDATE ? SET public = '?', visible = '?', downloadable = '?', fullscreen = '?', shareable = '?', password = NULL WHERE id IN (?)", array(LYCHEE_TABLE_ALBUMS, $public, $visible, $downloadable, $fullscreen, $shareable, $this->albumIDs));
 		$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
 		if ($result===false) return false;

--- a/php/database/albums_table.sql
+++ b/php/database/albums_table.sql
@@ -9,6 +9,8 @@ CREATE TABLE IF NOT EXISTS `?` (
   `public` tinyint(1) NOT NULL DEFAULT '0',
   `visible` tinyint(1) NOT NULL DEFAULT '1',
   `downloadable` tinyint(1) NOT NULL DEFAULT '0',
+  `fullscreen` tinyint(1) NOT NULL DEFAULT '0',
+  `shareable` tinyint(1) NOT NULL DEFAULT '0',
   `password` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/php/database/update_jnsnkrllive.php
+++ b/php/database/update_jnsnkrllive.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Update to version [jnsnkrllive]
+ */
+
+use Lychee\Modules\Database;
+use Lychee\Modules\Response;
+
+// Add 'fullscreen' column to album table
+$query1  = Database::prepare($connection, "ALTER TABLE `?` ADD `fullscreen` tinyint(1) NOT NULL DEFAULT '0'", array(LYCHEE_TABLE_ALBUMS));
+$result1 = Database::execute($connection, $query1, 'update_jnsnkrllive', __LINE__);
+if ($result1===false) Response::error('Could not add fullscreen column to album table!');
+
+// Add 'shareable' column to album table
+$query2  = Database::prepare($connection, "ALTER TABLE `?` ADD `shareable` tinyint(1) NOT NULL DEFAULT '0'", array(LYCHEE_TABLE_ALBUMS));
+$result2 = Database::execute($connection, $query2, 'update_jnsnkrllive', __LINE__);
+if ($result2===false) Response::error('Could not add shareable column to album table!');
+
+// Set version
+if (Database::setVersion($connection, 'jnsnkrllive')===false) Response::error('Could not update version of database!');
+
+?>

--- a/src/scripts/album.js
+++ b/src/scripts/album.js
@@ -404,6 +404,22 @@ album.setPublic = function(albumID, modal, e) {
 		              </div>
 		              <div class='choice'>
 		                  <label>
+		                      <input type='checkbox' name='fullscreen'>
+		                      <span class='checkbox'>${ build.iconic('check') }</span>
+		                      <span class='label'>Enable Full Screen View</span>
+		                  </label>
+		                  <p>Visitors of your Lychee can view photos in this album with the full screen.</p>
+		              </div>
+		              <div class='choice'>
+		                  <label>
+		                      <input type='checkbox' name='shareable'>
+		                      <span class='checkbox'>${ build.iconic('check') }</span>
+		                      <span class='label'>Shareable</span>
+		                  </label>
+		                  <p>Visitors of your Lychee can share this album.</p>
+		              </div>
+		              <div class='choice'>
+		                  <label>
 		                      <input type='checkbox' name='password'>
 		                      <span class='checkbox'>${ build.iconic('check') }</span>
 		                      <span class='label'>Password protected</span>
@@ -430,6 +446,8 @@ album.setPublic = function(albumID, modal, e) {
 
 		if (album.json.public==='1' && album.json.visible==='0') $('.basicModal .choice input[name="hidden"]').click()
 		if (album.json.downloadable==='1')                       $('.basicModal .choice input[name="downloadable"]').click()
+		if (album.json.fullscreen==='1')                         $('.basicModal .choice input[name="fullscreen"]').click()
+		if (album.json.shareable==='1')                          $('.basicModal .choice input[name="shareable"]').click()
 
 		$('.basicModal .choice input[name="password"]').on('change', function() {
 
@@ -456,6 +474,14 @@ album.setPublic = function(albumID, modal, e) {
 		if ($('.basicModal .choice input[name="downloadable"]:checked').length===1) album.json.downloadable = '1'
 		else                                                                        album.json.downloadable = '0'
 
+		// Set fullscreen
+		if ($('.basicModal .choice input[name="fullscreen"]:checked').length===1) album.json.fullscreen = '1'
+		else                                                                      album.json.fullscreen = '0'
+
+		// Set shareable
+		if ($('.basicModal .choice input[name="shareable"]:checked').length===1) album.json.shareable = '1'
+		else                                                                     album.json.shareable = '0'
+
 		// Set password
 		if ($('.basicModal .choice input[name="password"]:checked').length===1) {
 			password            = $('.basicModal .choice input[name="passwordtext"]').val()
@@ -480,11 +506,15 @@ album.setPublic = function(albumID, modal, e) {
 
 		album.json.visible      = (album.json.public==='0') ? '1' : album.json.visible
 		album.json.downloadable = (album.json.public==='0') ? '0' : album.json.downloadable
+		album.json.fullscreen   = (album.json.public==='0') ? '0' : album.json.fullscreen
+		album.json.shareable    = (album.json.public==='0') ? '0' : album.json.shareable
 		album.json.password     = (album.json.public==='0') ? '0' : album.json.password
 
 		view.album.public()
 		view.album.hidden()
 		view.album.downloadable()
+		view.album.fullscreen()
+		view.album.shareable()
 		view.album.password()
 
 		if (album.json.public==='1') contextMenu.shareAlbum(albumID, e)
@@ -496,7 +526,9 @@ album.setPublic = function(albumID, modal, e) {
 		public       : album.json.public,
 		password     : password,
 		visible      : album.json.visible,
-		downloadable : album.json.downloadable
+		downloadable : album.json.downloadable,
+		fullscreen   : album.json.fullscreen,
+		shareable    : album.json.shareable
 	}
 
 	api.post('Album::setPublic', params, function(data) {
@@ -523,6 +555,10 @@ album.share = function(service) {
 			break
 	}
 
+}
+
+album.isShareable = function() {
+	return (album.json.shareable==='1')
 }
 
 album.getArchive = function(albumID) {

--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -238,8 +238,13 @@ contextMenu.photoMore = function(photoID, e) {
 	// b) Downloadable is 1 and public mode is on
 	let showDownload = lychee.publicMode===false || ((album.json && album.json.downloadable && album.json.downloadable==='1') && lychee.publicMode===true)
 
+	// Show fullscreen-item when
+	// a) Public mode is off
+	// b) Fullscreen is 1 and public mode is on
+	let showFullScreen = lychee.publicMode===false || ((album.json && album.json.fullscreen && album.json.fullscreen==='1') && lychee.publicMode===true)
+
 	let items = [
-		{ title: build.iconic('fullscreen-enter') + 'Full Photo', fn: () => window.open(photo.getDirectLink()) },
+		{ title: build.iconic('fullscreen-enter') + 'Full Photo', visible: showFullScreen, fn: () => window.open(photo.getDirectLink()) },
 		{ title: build.iconic('cloud-download') + 'Download', visible: showDownload, fn: () => photo.getArchive(photoID) }
 	]
 
@@ -299,18 +304,19 @@ contextMenu.sharePhoto = function(photoID, e) {
 	let iconClass = 'ionicons'
 
 	let items = [
-		{ title: `<input readonly id="link" value="${ link }">`, fn: () => {}, class: 'basicContext__item--noHover' },
+		{ title: `<input readonly id="link" value="${ link }">`, visible: photo.isShareable(), fn: () => {}, class: 'basicContext__item--noHover' },
 		{ },
-		{ title: build.iconic('twitter', iconClass) + 'Twitter', fn: () => photo.share(photoID, 'twitter') },
-		{ title: build.iconic('facebook', iconClass) + 'Facebook', fn: () => photo.share(photoID, 'facebook') },
-		{ title: build.iconic('envelope-closed') + 'Mail', fn: () => photo.share(photoID, 'mail') },
-		{ title: build.iconic('dropbox', iconClass) + 'Dropbox', visible: lychee.publicMode===false, fn: () => photo.share(photoID, 'dropbox') },
-		{ title: build.iconic('link-intact') + 'Direct Link', fn: () => window.open(photo.getDirectLink()) },
+		{ title: build.iconic('twitter', iconClass) + 'Twitter', visible: photo.isShareable(), fn: () => photo.share(photoID, 'twitter') },
+		{ title: build.iconic('facebook', iconClass) + 'Facebook', visible: photo.isShareable(), fn: () => photo.share(photoID, 'facebook') },
+		{ title: build.iconic('envelope-closed') + 'Mail', visible: photo.isShareable(), fn: () => photo.share(photoID, 'mail') },
+		{ title: build.iconic('dropbox', iconClass) + 'Dropbox', visible: photo.isShareable() && lychee.publicMode===false, fn: () => photo.share(photoID, 'dropbox') },
+		{ title: build.iconic('link-intact') + 'Direct Link', visible: photo.isShareable(), fn: () => window.open(photo.getDirectLink()) },
 		{ },
 		{ title: build.iconic('ban') + 'Make Private', visible: lychee.publicMode===false, fn: () => photo.setPublic(photoID) }
 	]
 
-	if (lychee.publicMode===true) items.splice(7, 1)
+	if (!photo.isShareable() || lychee.publicMode===true) items.splice(7, 1)
+	if (!photo.isShareable()) items.splice(1, 1)
 
 	basicContext.show(items, e.originalEvent)
 	$('.basicContext input#link').focus().select()
@@ -322,17 +328,18 @@ contextMenu.shareAlbum = function(albumID, e) {
 	let iconClass = 'ionicons'
 
 	let items = [
-		{ title: `<input readonly id="link" value="${ location.href }">`, fn: () => {}, class: 'basicContext__item--noHover' },
+		{ title: `<input readonly id="link" value="${ location.href }">`, visible: album.isShareable(), fn: () => {}, class: 'basicContext__item--noHover' },
 		{ },
-		{ title: build.iconic('twitter', iconClass) + 'Twitter', fn: () => album.share('twitter') },
-		{ title: build.iconic('facebook', iconClass) + 'Facebook', fn: () => album.share('facebook') },
-		{ title: build.iconic('envelope-closed') + 'Mail', fn: () => album.share('mail') },
+		{ title: build.iconic('twitter', iconClass) + 'Twitter', visible: album.isShareable(), fn: () => album.share('twitter') },
+		{ title: build.iconic('facebook', iconClass) + 'Facebook', visible: album.isShareable(), fn: () => album.share('facebook') },
+		{ title: build.iconic('envelope-closed') + 'Mail', visible: album.isShareable(), fn: () => album.share('mail') },
 		{ },
 		{ title: build.iconic('pencil') + 'Edit Sharing', visible: lychee.publicMode===false, fn: () => album.setPublic(albumID, true, e) },
 		{ title: build.iconic('ban') + 'Make Private', visible: lychee.publicMode===false, fn: () => album.setPublic(albumID, false) }
 	]
 
-	if (lychee.publicMode===true) items.splice(5, 1)
+	if (!album.isShareable() || lychee.publicMode===true) items.splice(5, 1)
+	if (!album.isShareable()) items.splice(1, 1)
 
 	basicContext.show(items, e.originalEvent)
 	$('.basicContext input#link').focus().select()

--- a/src/scripts/header.js
+++ b/src/scripts/header.js
@@ -148,6 +148,9 @@ header.setMode = function(mode) {
 				$('#button_info_album, #button_trash_album, #button_share_album').show()
 			}
 
+			// Hide share button when not logged in and album is not shareable
+			if (lychee.publicMode===true && !album.isShareable()) $('#button_share_album').hide()
+
 			return true
 			break
 
@@ -156,6 +159,12 @@ header.setMode = function(mode) {
 			header.dom().addClass('header--view')
 			header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--album').removeClass('header__toolbar--visible')
 			header.dom('.header__toolbar--photo').addClass('header__toolbar--visible')
+
+			// Hide share button when not logged in and photo is not shareable
+			if (lychee.publicMode===true && !photo.isShareable()) $('#button_share').hide()
+
+			// Hide more button when not logged in and photo is not downloadable or viewable on full screen
+			if (lychee.publicMode===true && !photo.isFullScreen() && album.json.downloadable==='0') $('#button_more').hide()
 
 			return true
 			break

--- a/src/scripts/photo.js
+++ b/src/scripts/photo.js
@@ -634,6 +634,14 @@ photo.share = function(photoID, service) {
 
 }
 
+photo.isFullScreen = function() {
+	return (album.json.fullscreen==='1')
+}
+
+photo.isShareable = function() {
+	return (album.json.shareable==='1')
+}
+
 photo.getArchive = function(photoID) {
 
 	let link

--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -225,6 +225,8 @@ sidebar.createStructure.album = function(data) {
 	let _public      = ''
 	let hidden       = ''
 	let downloadable = ''
+	let fullscreen   = ''
+	let shareable    = ''
 	let password     = ''
 
 	// Enable editable when user logged in
@@ -266,6 +268,30 @@ sidebar.createStructure.album = function(data) {
 
 	}
 
+	// Set value for fullscreen
+	switch (data.fullscreen) {
+
+		case '0' : fullscreen = 'No'
+		           break
+		case '1' : fullscreen = 'Yes'
+		           break
+		default  : fullscreen = '-'
+		           break
+
+	}
+
+	// Set value for shareable
+	switch (data.shareable) {
+
+		case '0' : shareable = 'No'
+		           break
+		case '1' : shareable = 'Yes'
+		           break
+		default  : shareable = '-'
+		           break
+
+	}
+
 	// Set value for password
 	switch (data.password) {
 
@@ -303,6 +329,8 @@ sidebar.createStructure.album = function(data) {
 			{ title: 'Public',       value: _public },
 			{ title: 'Hidden',       value: hidden },
 			{ title: 'Downloadable', value: downloadable },
+			{ title: 'Full Screen',  value: fullscreen },
+			{ title: 'Shareable',    value: shareable },
 			{ title: 'Password',     value: password }
 		]
 	}

--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -260,6 +260,20 @@ view.album = {
 
 	},
 
+	fullscreen: function() {
+
+		if (album.json.fullscreen==='1') sidebar.changeAttr('fullscreen', 'Yes')
+		else                             sidebar.changeAttr('fullscreen', 'No')
+
+	},
+
+	shareable: function() {
+
+		if (album.json.shareable==='1') sidebar.changeAttr('shareable', 'Yes')
+		else                            sidebar.changeAttr('shareable', 'No')
+
+	},
+
 	password: function() {
 
 		if (album.json.password==='1') sidebar.changeAttr('password', 'Yes')


### PR DESCRIPTION
Adds options to control access to the full screen button and the social sharing buttons on an album.

Sharing Options:
![image](https://cloud.githubusercontent.com/assets/6225628/19246941/a9d9f140-8edd-11e6-83f9-a47c307caeea.png)

Full Screen button on the photo view:
![image](https://cloud.githubusercontent.com/assets/6225628/19246825/1cd8b45c-8edd-11e6-833f-e36a9bb43543.png)

Social Sharing buttons on the album view:
![image](https://cloud.githubusercontent.com/assets/6225628/19246876/528bb496-8edd-11e6-83fe-d11340dac122.png)

Social Sharing buttons on the photo view:
![image](https://cloud.githubusercontent.com/assets/6225628/19246899/6b980156-8edd-11e6-914e-88cb33dbb51f.png)
