### PR TITLE
Contextmenu in search view?

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -120,8 +120,8 @@ These hooks are called from `php/modules/Photo.php`.
 | Photo::get:after |  |
 | Photo::getInfo:before | Lychee reads the metadata of an image |
 | Photo::getInfo:after |  |
-| Photo::getArchive:before | User downloads photo |
-| Photo::getArchive:after |  |
+| Photo::getPhoto:before | User downloads photo |
+| Photo::getPhoto:after |  |
 | Photo::setTitle:before | User renames photo |
 | Photo::setTitle:after |  |
 | Photo::setDescription:before | User sets description |

--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -61,7 +61,7 @@ final class Admin extends Access {
 
 			// $_GET functions
 			case 'Album::getArchive':       self::getAlbumArchiveAction(); break;
-			case 'Photo::getArchive':       self::getPhotoArchiveAction(); break;
+			case 'Photo::getPhoto':         self::getPhotoFileAction(); break;
 
 		}
 
@@ -341,12 +341,12 @@ final class Admin extends Access {
 
 	}
 
-	private static function getPhotoArchiveAction() {
+	private static function getPhotoFileAction() {
 
 		Validator::required(isset($_GET['photoID']), __METHOD__);
 
 		$photo = new Photo($_GET['photoID']);
-		$photo->getArchive();
+		$photo->getPhoto();
 
 	}
 

--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -61,6 +61,7 @@ final class Admin extends Access {
 
 			// $_GET functions
 			case 'Album::getArchive':       self::getAlbumArchiveAction(); break;
+			case 'Photo::getArchive':       self::getPhotoArchiveAction(); break;
 			case 'Photo::getPhoto':         self::getPhotoFileAction(); break;
 
 		}
@@ -338,6 +339,15 @@ final class Admin extends Access {
 
 		$album = new Album($_GET['albumIDs']);
 		$album->getArchive();
+
+	}
+
+	private static function getPhotoArchiveAction() {
+
+		Validator::required(isset($_GET['photoIDs']), __METHOD__);
+
+		$photo = new Photo($_GET['photoIDs']);
+		$photo->getArchive();
 
 	}
 

--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -334,9 +334,9 @@ final class Admin extends Access {
 
 	private static function getAlbumArchiveAction() {
 
-		Validator::required(isset($_GET['albumID']), __METHOD__);
+		Validator::required(isset($_GET['albumIDs']), __METHOD__);
 
-		$album = new Album($_GET['albumID']);
+		$album = new Album($_GET['albumIDs']);
 		$album->getArchive();
 
 	}

--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -32,7 +32,7 @@ final class Guest extends Access {
 
 			// $_GET functions
 			case 'Album::getArchive': self::getAlbumArchiveAction(); break;
-			case 'Photo::getArchive': self::getPhotoArchiveAction(); break;
+			case 'Photo::getPhoto':   self::getPhotoFileAction(); break;
 
 		}
 
@@ -159,7 +159,7 @@ final class Guest extends Access {
 
 	}
 
-	private static function getPhotoArchiveAction() {
+	private static function getPhotoFileAction() {
 
 		Validator::required(isset($_GET['photoID'], $_GET['password']), __METHOD__);
 
@@ -171,7 +171,7 @@ final class Guest extends Access {
 		if ($pgP===2) {
 
 			// Photo Public
-			$photo->getArchive();
+			$photo->getPhoto();
 
 		} else {
 

--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -140,9 +140,9 @@ final class Guest extends Access {
 
 	private static function getAlbumArchiveAction() {
 
-		Validator::required(isset($_GET['albumID'], $_GET['password']), __METHOD__);
+		Validator::required(isset($_GET['albumIDs'], $_GET['password']), __METHOD__);
 
-		$album = new Album($_GET['albumID']);
+		$album = new Album($_GET['albumIDs']);
 
 		if ($album->getPublic()&&$album->getDownloadable()) {
 

--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -32,6 +32,7 @@ final class Guest extends Access {
 
 			// $_GET functions
 			case 'Album::getArchive': self::getAlbumArchiveAction(); break;
+			case 'Photo::getArchive': self::getPhotoArchiveAction(); break;
 			case 'Photo::getPhoto':   self::getPhotoFileAction(); break;
 
 		}
@@ -159,6 +160,19 @@ final class Guest extends Access {
 
 	}
 
+	private static function getPhotoArchiveAction() {
+
+		Validator::required(isset($_GET['photoIDs']), $_GET['password'], __METHOD__);
+
+		$photo = new Photo($_GET['photoIDs']);
+
+		$pgP = $photo->getPublic($_GET['password']);
+
+		if ($pgP===2) $photo->getArchive();
+		else          Response::warning('Photo private or password incorrect!');
+
+	}
+
 	private static function getPhotoFileAction() {
 
 		Validator::required(isset($_GET['photoID'], $_GET['password']), __METHOD__);
@@ -167,18 +181,8 @@ final class Guest extends Access {
 
 		$pgP = $photo->getPublic($_GET['password']);
 
-		// Photo Download
-		if ($pgP===2) {
-
-			// Photo Public
-			$photo->getPhoto();
-
-		} else {
-
-			// Photo Private
-			Response::warning('Photo private or password incorrect!');
-
-		}
+		if ($pgP===2) $photo->getPhoto();
+		else          Response::warning('Photo private or password incorrect!');
 
 	}
 

--- a/php/Modules/Archive.php
+++ b/php/Modules/Archive.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Lychee\Modules;
+
+use ZipArchive;
+
+/**
+ * Allows the creation of zip archive for albums and photos.
+ */
+final class Archive {
+
+	private $title;
+
+	private $filename;
+
+	private $zip;
+
+	/**
+	 * Creates a new zip archive in LYCHEE_DATA with given title.
+	 *
+	 * @param string $title the title
+	 */
+	public function __construct($title) {
+
+		// Escape title
+		$this->title = $this->cleanZipName($title);
+
+		$this->filename = LYCHEE_DATA . $this->title . '.zip';
+
+		// Create zip
+		$this->zip = new ZipArchive();
+		if ($this->zip->open($this->filename, ZIPARCHIVE::CREATE)!==TRUE) {
+			Log::error(Database::get(), __METHOD__, __LINE__, 'Could not create ZipArchive');
+			$this->zip = null;
+		}
+
+	}
+
+	public function __destruct() {
+
+		if ($this->zip!==null) $this->zip->close();
+
+		unlink($this->filename);
+
+	}
+
+	/**
+	 * Closes the zip file and sends it to the browser.
+	 */
+	public function send() {
+
+		// Finish zip
+		$this->zip->close();
+		$this->zip = null;
+
+		// Send zip
+		header("Content-Type: application/zip");
+		header("Content-Disposition: attachment; filename=\"" . $this->title . ".zip\"");
+		header("Content-Length: " . filesize($this->filename));
+		readfile($this->filename);
+
+	}
+
+	/**
+	 * Adds the given album including subalbums at given path to the zip archive.
+	 *
+	 * @param string $path the path in the zip archive
+	 * @param int $albumID the id of the album
+	 * @return true on success
+	 */
+	public function addAlbum($path, $albumID) {
+
+		// Fetch photos
+		$query = Database::prepare(Database::get(), "SELECT title, url FROM ? WHERE album = '?'", array(LYCHEE_TABLE_PHOTOS, $albumID));
+
+		if (!$this->addPhotos($path, $query)) return false;
+
+		// Fetch subalbums
+		$query = Database::prepare(Database::get(), "SELECT id, title FROM ? WHERE parent = '?'", array(LYCHEE_TABLE_ALBUMS, $albumID));
+		$albums = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
+
+		if ($albums===false) return false;
+
+		// Add them recursively
+		while($album = $albums->fetch_assoc()) {
+			if (!$this->addAlbum($path . '/' . $this->cleanZipName($album['title']), $album['id'])) return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Adds the photos that are selected by the given query at given path to the zip archive.
+	 *
+	 * @param string $path the path in the zip archive
+	 * @param mysqli_stmt $query the SQL query to execute
+	 * @return true on success
+	 */
+	public function addPhotos($path, $query) {
+
+		if ($this->zip===null) return false;
+
+		$photos = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
+
+		if (!$photos) return false;
+
+		// Parse each path
+		$files = array();
+		while ($photo = $photos->fetch_object()) {
+
+			// Parse url
+			$photo->url = LYCHEE_UPLOADS_BIG . $photo->url;
+
+			// Parse title
+			$photo->title = $this->cleanZipName($photo->title);
+			if (!isset($photo->title)||$photo->title==='') $photo->title = 'Untitled';
+
+			// Check if readable
+			if (!@is_readable($photo->url)) continue;
+
+			// Get extension of image
+			$extension = getExtension($photo->url, false);
+
+			// Set title for photo
+			$zipFileName = $path . '/' . $photo->title . $extension;
+
+			// Check for duplicates
+			if (!empty($files)) {
+				$i = 1;
+				while (in_array($zipFileName, $files)) {
+
+					// Set new title for photo
+					$zipFileName = $path . '/' . $photo->title . '-' . $i . $extension;
+
+					$i++;
+
+				}
+			}
+
+			// Add to array
+			$files[] = $zipFileName;
+
+			// Add photo to zip
+			$this->zip->addFile($photo->url, $zipFileName);
+
+		}
+
+		return true;
+
+	}
+
+	private function cleanZipName($name) {
+
+		// Illicit chars
+		$badChars = array_merge(
+			array_map('chr', range(0,31)),
+			array("<", ">", ":", '"', "/", "\\", "|", "?", "*")
+		);
+
+		return str_replace($badChars, '', $name);
+
+	}
+
+}
+
+?>

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -889,9 +889,9 @@ final class Photo {
 
 	/**
 	 * Starts a download of a photo.
-	 * @return resource|boolean Sends a ZIP-file or returns false on failure.
+	 * @return resource|boolean Sends the photo or returns false on failure.
 	 */
-	public function getArchive() {
+	public function getPhoto() {
 
 		// Check dependencies
 		Validator::required(isset($this->photoIDs), __METHOD__);

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -2,7 +2,6 @@
 
 namespace Lychee\Modules;
 
-use ZipArchive;
 use Imagick;
 use ImagickPixel;
 

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -949,6 +949,33 @@ final class Photo {
 	}
 
 	/**
+	 * Starts a download of photos.
+	 * @return resource|boolean Sends a ZIP-file or returns false on failure.
+	 */
+	public function getArchive() {
+
+		// Check dependencies
+		Validator::required(isset($this->photoIDs), __METHOD__);
+
+		// Call plugins
+		Plugins::get()->activate(__METHOD__, 0, func_get_args());
+
+		$archive = new Archive('Photos');
+
+		$query   = Database::prepare(Database::get(), 'SELECT title, url FROM ? WHERE id IN (?)', array(LYCHEE_TABLE_PHOTOS, $this->photoIDs));
+
+        if (!$archive->addPhotos('', $query)) return false;
+
+		$archive->send();
+
+		// Call plugins
+		Plugins::get()->activate(__METHOD__, 1, func_get_args());
+
+		return true;
+
+	}
+
+	/**
 	 * Sets the title of a photo.
 	 * @return boolean Returns true when successful.
 	 */

--- a/php/helpers/search.php
+++ b/php/helpers/search.php
@@ -29,6 +29,11 @@ function search($term) {
 	while($photo = $result->fetch_assoc()) {
 
 		$photo = Photo::prepareData($photo);
+
+		// for operations in the search view
+		$photo['nextPhoto'] = '';
+		$photo['previousPhoto'] = '';
+
 		$return['photos'][$photo['id']] = $photo;
 
 	}

--- a/src/scripts/album.js
+++ b/src/scripts/album.js
@@ -625,13 +625,16 @@ album.share = function(service) {
 
 }
 
-album.getArchive = function(albumID) {
+album.getArchive = function(albumIDs) {
 
 	let link = ''
-	let url  = `${ api.path }?function=Album::getArchive&albumID=${ albumID }`
+	let url  = `${ api.path }?function=Album::getArchive&albumIDs=${ albumIDs.join(',') }`
 
-	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url)
-	else                                       link = location.href.replace(location.hash, '') + url
+	var pos = location.href.indexOf('#')
+	link = pos!=-1 ? location.href.substring(0, pos) : location.href
+
+	if (location.href.indexOf('index.html')>0) link = link.replace('index.html', url)
+	else                                       link += url
 
 	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`
 

--- a/src/scripts/album.js
+++ b/src/scripts/album.js
@@ -627,18 +627,12 @@ album.share = function(service) {
 
 album.getArchive = function(albumIDs) {
 
-	let link = ''
-	let url  = `${ api.path }?function=Album::getArchive&albumIDs=${ albumIDs.join(',') }`
+	let path  = `${ api.path }?function=Album::getArchive&albumIDs=${ albumIDs.join(',') }`
+	let url = lychee.getURL(path)
 
-	var pos = location.href.indexOf('#')
-	link = pos!=-1 ? location.href.substring(0, pos) : location.href
+	if (lychee.publicMode===true) url += `&password=${ encodeURIComponent(password.value) }`
 
-	if (location.href.indexOf('index.html')>0) link = link.replace('index.html', url)
-	else                                       link += url
-
-	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`
-
-	location.href = link
+	location.href = url
 
 }
 

--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -310,7 +310,7 @@ contextMenu.photoMore = function(photoID, e) {
 
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + 'Full Photo', fn: () => window.open(photo.getDirectLink()) },
-		{ title: build.iconic('cloud-download') + 'Download', visible: showDownload, fn: () => photo.getArchive(photoID) }
+		{ title: build.iconic('cloud-download') + 'Download', visible: showDownload, fn: () => photo.getPhoto(photoID) }
 	]
 
 	basicContext.show(items, e.originalEvent)

--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -115,6 +115,7 @@ contextMenu.album = function(albumID, e) {
 	if (album.isSmartID(albumID)) return false
 
 	let items = [
+		{ title: build.iconic('cloud-download') + 'Download', fn: () => album.getArchive([ albumID ]) },
 		{ title: build.iconic('pencil') + 'Rename', fn: () => album.setTitle([ albumID ]) },
 		{ title: build.iconic('collapse-left') + 'Merge', fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumID, e) } },
 		{ title: build.iconic('folder') + 'Move', fn: () => { basicContext.close(); contextMenu.moveAlbum([ albumID ], e) } },
@@ -136,6 +137,7 @@ contextMenu.albumMulti = function(albumIDs, e) {
 	let autoMerge = (albumIDs.length>1 ? true : false)
 
 	let items = [
+		{ title: build.iconic('cloud-download') + 'Download All', fn: () => album.getArchive(albumIDs) },
 		{ title: build.iconic('pencil') + 'Rename All', fn: () => album.setTitle(albumIDs) },
 		{ title: build.iconic('collapse-left') + 'Merge All', visible: autoMerge, fn: () => album.merge(albumIDs) },
 		{ title: build.iconic('collapse-left') + 'Merge', visible: !autoMerge, fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumIDs[0], e) } },

--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -244,6 +244,7 @@ contextMenu.photo = function(photoID, e) {
 	// in order to keep the selection
 
 	let items = [
+		{ title: build.iconic('cloud-download') + 'Download', fn: () => photo.getPhoto(photoID) },
 		{ title: build.iconic('star') + 'Star', fn: () => photo.setStar([ photoID ]) },
 		{ title: build.iconic('tag') + 'Tags', fn: () => photo.editTags([ photoID ]) },
 		{ },
@@ -268,6 +269,7 @@ contextMenu.photoMulti = function(photoIDs, e) {
 	// in order to keep the selection and multiselect
 
 	let items = [
+		{ title: build.iconic('cloud-download') + 'Download All', fn: () => photo.getArchive(photoIDs) },
 		{ title: build.iconic('star') + 'Star All', fn: () => photo.setStar(photoIDs) },
 		{ title: build.iconic('tag') + 'Tag All', fn: () => photo.editTags(photoIDs) },
 		{ },

--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -116,10 +116,10 @@ contextMenu.album = function(albumID, e) {
 
 	let items = [
 		{ title: build.iconic('cloud-download') + 'Download', fn: () => album.getArchive([ albumID ]) },
-		{ title: build.iconic('pencil') + 'Rename', fn: () => album.setTitle([ albumID ]) },
-		{ title: build.iconic('collapse-left') + 'Merge', fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumID, e) } },
-		{ title: build.iconic('folder') + 'Move', fn: () => { basicContext.close(); contextMenu.moveAlbum([ albumID ], e) } },
-		{ title: build.iconic('trash') + 'Delete', fn: () => album.delete([ albumID ]) }
+		{ title: build.iconic('pencil') + 'Rename', visible: !lychee.publicMode, fn: () => album.setTitle([ albumID ]) },
+		{ title: build.iconic('collapse-left') + 'Merge', visible: !lychee.publicMode, fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumID, e) } },
+		{ title: build.iconic('folder') + 'Move', visible: !lychee.publicMode, fn: () => { basicContext.close(); contextMenu.moveAlbum([ albumID ], e) } },
+		{ title: build.iconic('trash') + 'Delete', visible: !lychee.publicMode, fn: () => album.delete([ albumID ]) }
 	]
 
 	multiselect.select('.album[data-id="' + albumID + '"]')
@@ -138,11 +138,11 @@ contextMenu.albumMulti = function(albumIDs, e) {
 
 	let items = [
 		{ title: build.iconic('cloud-download') + 'Download All', fn: () => album.getArchive(albumIDs) },
-		{ title: build.iconic('pencil') + 'Rename All', fn: () => album.setTitle(albumIDs) },
-		{ title: build.iconic('collapse-left') + 'Merge All', visible: autoMerge, fn: () => album.merge(albumIDs) },
-		{ title: build.iconic('collapse-left') + 'Merge', visible: !autoMerge, fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumIDs[0], e) } },
-		{ title: build.iconic('folder') + 'Move All', fn: () => { basicContext.close(); contextMenu.moveAlbum(albumIDs, e) } },
-		{ title: build.iconic('trash') + 'Delete All', fn: () => album.delete(albumIDs) }
+		{ title: build.iconic('pencil') + 'Rename All', visible: !lychee.publicMode, fn: () => album.setTitle(albumIDs) },
+		{ title: build.iconic('collapse-left') + 'Merge All', visible: !lychee.publicMode && autoMerge, fn: () => album.merge(albumIDs) },
+		{ title: build.iconic('collapse-left') + 'Merge', visible: !lychee.publicMode && !autoMerge, fn: () => { basicContext.close(); contextMenu.mergeAlbum(albumIDs[0], e) } },
+		{ title: build.iconic('folder') + 'Move All', visible: !lychee.publicMode, fn: () => { basicContext.close(); contextMenu.moveAlbum(albumIDs, e) } },
+		{ title: build.iconic('trash') + 'Delete All', visible: !lychee.publicMode, fn: () => album.delete(albumIDs) }
 	]
 
 	items.push()
@@ -244,15 +244,20 @@ contextMenu.photo = function(photoID, e) {
 	// in order to keep the selection
 
 	let items = [
-		{ title: build.iconic('cloud-download') + 'Download', fn: () => photo.getPhoto(photoID) },
-		{ title: build.iconic('star') + 'Star', fn: () => photo.setStar([ photoID ]) },
-		{ title: build.iconic('tag') + 'Tags', fn: () => photo.editTags([ photoID ]) },
-		{ },
-		{ title: build.iconic('pencil') + 'Rename', fn: () => photo.setTitle([ photoID ]) },
-		{ title: build.iconic('layers') + 'Duplicate', fn: () => photo.duplicate([ photoID ]) },
-		{ title: build.iconic('folder') + 'Move', fn: () => { basicContext.close(); contextMenu.move([ photoID ], e) } },
-		{ title: build.iconic('trash') + 'Delete', fn: () => photo.delete([ photoID ]) }
+		{ title: build.iconic('cloud-download') + 'Download', fn: () => photo.getPhoto(photoID) }
 	]
+
+	if (!lychee.publicMode) {
+		items = items.concat([
+			{ title: build.iconic('star') + 'Star', fn: () => photo.setStar([ photoID ]) },
+			{ title: build.iconic('tag') + 'Tags', fn: () => photo.editTags([ photoID ]) },
+			{ },
+			{ title: build.iconic('pencil') + 'Rename', fn: () => photo.setTitle([ photoID ]) },
+			{ title: build.iconic('layers') + 'Duplicate', fn: () => photo.duplicate([ photoID ]) },
+			{ title: build.iconic('folder') + 'Move', fn: () => { basicContext.close(); contextMenu.move([ photoID ], e) } },
+			{ title: build.iconic('trash') + 'Delete', fn: () => photo.delete([ photoID ]) }
+		])
+	}
 
 	multiselect.select('.photo[data-id="' + photoID + '"]')
 
@@ -269,15 +274,20 @@ contextMenu.photoMulti = function(photoIDs, e) {
 	// in order to keep the selection and multiselect
 
 	let items = [
-		{ title: build.iconic('cloud-download') + 'Download All', fn: () => photo.getArchive(photoIDs) },
-		{ title: build.iconic('star') + 'Star All', fn: () => photo.setStar(photoIDs) },
-		{ title: build.iconic('tag') + 'Tag All', fn: () => photo.editTags(photoIDs) },
-		{ },
-		{ title: build.iconic('pencil') + 'Rename All', fn: () => photo.setTitle(photoIDs) },
-		{ title: build.iconic('layers') + 'Duplicate All', fn: () => photo.duplicate(photoIDs) },
-		{ title: build.iconic('folder') + 'Move All', fn: () => { basicContext.close(); contextMenu.move(photoIDs, e) } },
-		{ title: build.iconic('trash') + 'Delete All', fn: () => photo.delete(photoIDs) }
+		{ title: build.iconic('cloud-download') + 'Download All', fn: () => photo.getArchive(photoIDs) }
 	]
+
+	if (!lychee.publicMode) {
+		items = items.concat([
+			{ title: build.iconic('star') + 'Star All', fn: () => photo.setStar(photoIDs) },
+			{ title: build.iconic('tag') + 'Tag All', fn: () => photo.editTags(photoIDs) },
+			{ },
+			{ title: build.iconic('pencil') + 'Rename All', fn: () => photo.setTitle(photoIDs) },
+			{ title: build.iconic('layers') + 'Duplicate All', fn: () => photo.duplicate(photoIDs) },
+			{ title: build.iconic('folder') + 'Move All', fn: () => { basicContext.close(); contextMenu.move(photoIDs, e) } },
+			{ title: build.iconic('trash') + 'Delete All', fn: () => photo.delete(photoIDs) }
+		])
+	}
 
 	basicContext.show(items, e.originalEvent, contextMenu.close)
 

--- a/src/scripts/header.js
+++ b/src/scripts/header.js
@@ -49,7 +49,7 @@ header.bind = function() {
 	header.dom('.header__hostedwith') .on(eventName, function() { window.open(lychee.website) })
 	header.dom('#button_trash_album') .on(eventName, function() { album.delete([ album.getID() ]) })
 	header.dom('#button_trash')       .on(eventName, function() { photo.delete([ photo.getID() ]) })
-	header.dom('#button_archive')     .on(eventName, function() { album.getArchive(album.getID()) })
+	header.dom('#button_archive')     .on(eventName, function() { album.getArchive([ album.getID() ]) })
 	header.dom('#button_star')        .on(eventName, function() { photo.setStar([ photo.getID() ]) })
 	header.dom('#button_back_home')   .on(eventName, function() { lychee.goto(album.getParent()) })
 	header.dom('#button_back')        .on(eventName, function() { lychee.goto(album.getID()) })

--- a/src/scripts/lychee.js
+++ b/src/scripts/lychee.js
@@ -251,8 +251,6 @@ lychee.setMode = function(mode) {
 	$(document)
 		.off('click',       '.header__title--editable')
 		.off('touchend',    '.header__title--editable')
-		.off('contextmenu', '.photo')
-		.off('contextmenu', '.album')
 		.off('drop')
 
 	Mousetrap

--- a/src/scripts/lychee.js
+++ b/src/scripts/lychee.js
@@ -417,6 +417,18 @@ lychee.html = function(literalSections, ...substs) {
 
 }
 
+lychee.getURL = function(path) {
+
+	let pos = location.href.indexOf('#')
+	let url = pos!=-1 ? location.href.substring(0, pos) : location.href
+
+	if (location.href.indexOf('index.html')>0) url = url.replace('index.html', path)
+	else                                       url += path
+
+	return url
+
+}
+
 lychee.error = function(errorThrown, params, data) {
 
 	console.error({

--- a/src/scripts/multiselect.js
+++ b/src/scripts/multiselect.js
@@ -150,7 +150,6 @@ multiselect.clearSelection = function(deselect = true) {
 
 multiselect.show = function(e) {
 
-	if (lychee.publicMode)                          return false
 	if (!visible.albums() && !visible.album())      return false
 	if ($('.album:hover, .photo:hover').length!==0) return false
 	if (visible.search())                           return false

--- a/src/scripts/multiselect.js
+++ b/src/scripts/multiselect.js
@@ -152,7 +152,6 @@ multiselect.show = function(e) {
 
 	if (!visible.albums() && !visible.album())      return false
 	if ($('.album:hover, .photo:hover').length!==0) return false
-	if (visible.search())                           return false
 	if (visible.multiselect())                      $('#multiselect').remove()
 
 	sidebar.setSelectable(false)

--- a/src/scripts/photo.js
+++ b/src/scripts/photo.js
@@ -633,10 +633,10 @@ photo.share = function(photoID, service) {
 
 }
 
-photo.getArchive = function(photoID) {
+photo.getPhoto = function(photoID) {
 
 	let link
-	let url = `${ api.path }?function=Photo::getArchive&photoID=${ photoID }`
+	let url = `${ api.path }?function=Photo::getPhoto&photoID=${ photoID }`
 
 	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url)
 	else                                       link = location.href.replace(location.hash, '') + url

--- a/src/scripts/photo.js
+++ b/src/scripts/photo.js
@@ -647,6 +647,20 @@ photo.getPhoto = function(photoID) {
 
 }
 
+photo.getArchive = function(photoIDs) {
+
+	let link
+	let url = `${ api.path }?function=Photo::getArchive&photoIDs=${ photoIDs.join(',') }`
+
+	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url)
+	else                                       link = location.href.replace(location.hash, '') + url
+
+	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`
+
+	location.href = link
+
+}
+
 photo.getDirectLink = function() {
 
 	let url = ''

--- a/src/scripts/photo.js
+++ b/src/scripts/photo.js
@@ -635,29 +635,23 @@ photo.share = function(photoID, service) {
 
 photo.getPhoto = function(photoID) {
 
-	let link
-	let url = `${ api.path }?function=Photo::getPhoto&photoID=${ photoID }`
+	let path = `${ api.path }?function=Photo::getPhoto&photoID=${ photoID }`
+	let url = lychee.getURL(path)
 
-	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url)
-	else                                       link = location.href.replace(location.hash, '') + url
+	if (lychee.publicMode===true) url += `&password=${ encodeURIComponent(password.value) }`
 
-	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`
-
-	location.href = link
+	location.href = url
 
 }
 
 photo.getArchive = function(photoIDs) {
 
-	let link
-	let url = `${ api.path }?function=Photo::getArchive&photoIDs=${ photoIDs.join(',') }`
+	let path = `${ api.path }?function=Photo::getArchive&photoIDs=${ photoIDs.join(',') }`
+	let url = lychee.getURL(path)
 
-	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url)
-	else                                       link = location.href.replace(location.hash, '') + url
+	if (lychee.publicMode===true) url += `&password=${ encodeURIComponent(password.value) }`
 
-	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`
-
-	location.href = link
+	location.href = url
 
 }
 
@@ -673,9 +667,8 @@ photo.getDirectLink = function() {
 
 photo.getViewLink = function(photoID) {
 
-	let url = 'view.php?p=' + photoID
+	let path = 'view.php?p=' + photoID
 
-	if (location.href.indexOf('index.html')>0) return location.href.replace('index.html' + location.hash, url)
-	else                                       return location.href.replace(location.hash, url)
+	return lychee.getURL(path)
 
 }


### PR DESCRIPTION
This PR extends #646 to enable the context menu and therefore selective downloading of photos and albums in the search view. I'm not sure yet what the best solution is. Thus, I wanted to post the current status and start a discussion about it.

On the one hand, it makes a lot of sense IMO to enable the context menu in the search view as well. It could be handy for staring, tagging, deletion etc. On the other hand, not all features the context menu offers work out of the box. For example, duplicating a photo does not work at all. Moving lets the photo disappear from the search view, although it does probably still match the keywords. Renaming or changing tags might change whether it should match or not, but nothing happens at the moment. Merging is similarly problematic.

So, I guess there are at least three options:
  1. Simply keep the context menu disabled in the search view.
  2. Enabling the context menu, but hide the problematic items.
  3. Enable all context menu items and fix the issues.

The first is obviously the easiest one; the second is not much more complicated. Thus, the question is, it is worth it to enable all context menu items to justify the effort? I think that a simple solution could be to refresh the search view after the action that these menu items cause. This would require to encode the keywords in the URL, I guess, but should otherwise fix most if not all of the issues. Because pretty much all issues are caused by trying to fix things on the client instead of reloading things.