### PR TITLE
Downloading album : clean and flush before send zip file to avoid 500 error

### DIFF
--- a/php/Modules/Album.php
+++ b/php/Modules/Album.php
@@ -306,9 +306,14 @@ final class Album {
 		$zip->close();
 
 		// Send zip
-		header("Content-Type: application/zip");
-		header("Content-Disposition: attachment; filename=\"$zipTitle.zip\"");
-		header("Content-Length: " . filesize($filename));
+		header("Content-type: application/zip");
+		header("Content-disposition: attachment; filename=\"$zipTitle.zip\"");
+		header("Content-length: " . filesize($filename));
+
+		// Clean before, in order to avoid 500 error
+		ob_end_clean();
+		flush();
+
 		readfile($filename);
 
 		// Delete zip


### PR DESCRIPTION
When I downloading album, I always have 500 error.
After search, I found a fix, two instructions for cleaning before the download. 

Without those instructions, I can't use the feature. 