### PR TITLE
Update twitter card configuration

### DIFF
--- a/php/helpers/getGraphHeader.php
+++ b/php/helpers/getGraphHeader.php
@@ -25,7 +25,7 @@ function getGraphHeader($photoID) {
 
 	$parseUrl = parse_url('http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
 	$url      = '//' . $parseUrl['host'] . $parseUrl['path'] . '?' . $parseUrl['query'];
-	$picture  = '//' . $parseUrl['host'] . $parseUrl['path'] . '/../uploads/' . $dir . '/' . $row->url;
+	$picture  = 'http://' . $parseUrl['host'] . '/uploads/' . $dir . '/' . $row->url;
 
 	$url     = htmlentities($url);
 	$picture = htmlentities($picture);
@@ -39,9 +39,11 @@ function getGraphHeader($photoID) {
 	$return .= '<link rel="image_src" type="image/jpeg" href="' . $picture . '">';
 
 	$return .= '<!-- Twitter Meta Data -->';
-	$return .= '<meta name="twitter:card" content="photo">';
+	$return .= '<meta name="twitter:card" content="summary_large_image">';
 	$return .= '<meta name="twitter:title" content="' . $row->title . '">';
-	$return .= '<meta name="twitter:image:src" content="' . $picture . '">';
+	$return .= '<meta name="twitter:description" content="' . $row->description . ' - via Lychee">';
+	$return .= '<meta name="twitter:image" content="' . $picture . '">';
+	$return .= '<meta name="twitter:image:alt" content="' . $row->description . ' - via Lychee">';
 
 	$return .= '<!-- Facebook Meta Data -->';
 	$return .= '<meta property="og:title" content="' . $row->title . '">';

--- a/robots.txt
+++ b/robots.txt
@@ -5,4 +5,3 @@ Disallow: /docs/
 Disallow: /php/
 Disallow: /plugins/
 Disallow: /src/
-Disallow: /uploads/


### PR DESCRIPTION
Twitter deprecated the 'photo' card and replaced it with the 'summary_large_image' card.

This pull request implements that new card; it also removes '/uploads' from robots.txt, since that was preventing the Twitterbot from finding the image inline.

(It also adds more metadata, such as the photo name and description.)

One note: there is a 'twitter:site' field, where you can put your twitter handle, and that way if you get hotlinked you get credit. I didn't see an easy way to tie that into settings, so I left it out.

p.s. I am not a dev, so I apologize if I did not do things The Best Way. But I tested it locally and it works, and I tried to follow existing styles. Thanks!