### PR TITLE
Removed non-existing PHP directive upload_max_size

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,14 +6,12 @@ Options -Indexes
 #<IfModule mod_php5.c>
 #	php_value max_execution_time 200
 #	php_value post_max_size 200M
-#	php_value upload_max_size 200M
 #	php_value upload_max_filesize 20M
 #	php_value max_file_uploads 100
 #</IfModule>
 #<IfModule mod_php7.c>
 #	php_value max_execution_time 200
 #	php_value post_max_size 200M
-#	php_value upload_max_size 200M
 #	php_value upload_max_filesize 20M
 #	php_value max_file_uploads 100
 #</IfModule>

--- a/.user.ini
+++ b/.user.ini
@@ -3,6 +3,5 @@
 
 ;max_execution_time = 200
 ;post_max_size = 200M
-;upload_max_size = 200M
 ;upload_max_filesize = 20M
 ;max_file_uploads = 200

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,7 +11,6 @@ If possible, change these settings directly in your `php.ini`. We recommend to i
 
 	max_execution_time = 200
 	post_max_size = 100M
-	upload_max_size = 100M
 	upload_max_filesize = 20M
 	memory_limit = 256M
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,7 +9,6 @@ To use Lychee without restrictions, we recommend to increase the values of the f
 
 	max_execution_time = 200
 	post_max_size = 100M
-	upload_max_size = 100M
 	upload_max_filesize = 20M
 	memory_limit = 256M
 	


### PR DESCRIPTION
The PHP directive `upload_max_size` in `.htaccess`, `.user.ini`, `docs/Installation.md` and `docs/FAQ.md` doesn't exist. The right one is `upload_max_filesize`, which is already there.
See: http://php.net/manual/en/ini.core.php