### PR TITLE
Add index.php so that nginx does not complain

### DIFF
--- a/src/scripts/contextMenu.js
+++ b/src/scripts/contextMenu.js
@@ -30,8 +30,8 @@ contextMenu.settings = function(e) {
 		{ title: build.iconic('dropbox', 'ionicons') + 'Set Dropbox', fn: settings.setDropboxKey },
 		{ },
 		{ title: build.iconic('info') + 'About Lychee', fn: () => window.open(lychee.website) },
-		{ title: build.iconic('wrench') + 'Diagnostics', fn: () => window.open('plugins/Diagnostics/') },
-		{ title: build.iconic('align-left') + 'Show Log', fn: () => window.open('plugins/Log/') },
+		{ title: build.iconic('wrench') + 'Diagnostics', fn: () => window.open('plugins/Diagnostics/index.php') },
+		{ title: build.iconic('align-left') + 'Show Log', fn: () => window.open('plugins/Log/index.php') },
 		{ },
 		{ title: build.iconic('account-logout') + 'Sign Out', fn: lychee.logout }
 	]


### PR DESCRIPTION
If I use the URL Lychee/plugins/Diagnostics/ I get a « 403 Forbidden »
error from nginx.
By adding the index.php part I have a working URL without changing the
nginx configuration.