### PR TITLE
Import CLI wrapper

### DIFF
--- a/import-cron-wrapper.php
+++ b/import-cron-wrapper.php
@@ -1,0 +1,31 @@
+<?php
+namespace Lychee\Modules;
+
+if (php_sapi_name() == "cli") { //Only for CLI
+
+	require("/var/www/lychee/php/define.php");
+	require("/var/www/lychee/php/Modules/Import.php");
+	require("/var/www/lychee/php/Modules/Plugins.php");
+	require("/var/www/lychee/php/Modules/Settings.php");
+	require("/var/www/lychee/php/Modules/Database.php");
+	require("/var/www/lychee/php/Modules/Config.php");
+	require("/var/www/lychee/php/Modules/Validator.php");
+	require("/var/www/lychee/php/Modules/Photo.php");
+	require("/var/www/lychee/php/Modules/Log.php");
+	require("/var/www/lychee/php/helpers/hasPermissions.php");
+	require("/var/www/lychee/php/helpers/getExtension.php");
+	require("/var/www/lychee/php/helpers/generateID.php");
+
+	$import_location='/var/www/lychee/uploads/import/';
+
+	if (isset($argv[1])) {
+			$import_location=$argv[1];
+	}
+
+	$importer = new Import();
+	$importer->server($import_location);
+} else {
+	// Let's act like we're not there
+	http_response_code(404);
+}
+?>


### PR DESCRIPTION
Hi,

I understand that this might be out of scope, but anyhow I added a quick script which performs an import from server and is meant to be invoked from the command line.

The reason I made this is because I wanted to import approx.130 photos and, as my server was slow, I was getting time out every 10 photos.

CLI on the other hand, does not have a time out. Plus, with this script one will avoid the curl-with-cookie workarounds. Its usage is as simple as can be:

`php import-cron-wrapper.php [import path]`

Import path is optional and defaults to /var/www/lychee/uploads/import/

Name of script is unimportant (on a second thought, I should have used 'import-cli-wrapper'). The user, as an additional security measure can rename it as they wish or even move it outside from web document root.

This can be used:
a) to perform an initial import
b) together with cron, to create a "black hole" where, every photo that will be dropped in it, it will be imported (and then vanish)

Again, I understand that this might be out of scope, anyhow I thought it could be useful for somebody.

Thank you for the code,
Yannis
