### PR TITLE
ZipStream for subalbums

### DIFF
--- a/php/Access/Access.php
+++ b/php/Access/Access.php
@@ -2,12 +2,14 @@
 
 namespace Lychee\Access;
 
+use Exception;
 use Lychee\Modules\Response;
 
 abstract class Access {
 
-	final protected static function fnNotFound() {
-
+	final protected static function fnNotFound($fn) {
+        $e = new Exception;
+        error_log("$fn: Function not found!" . var_export($e->getTraceAsString(), true));
 		Response::error('Function not found! Please check the spelling of the called function.');
 
 	}

--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -63,9 +63,9 @@ final class Admin extends Access {
 			case 'Album::getArchive':       self::getAlbumArchiveAction(); break;
 			case 'Photo::getArchive':       self::getPhotoArchiveAction(); break;
 
+            default:  self::fnNotFound($fn);
 		}
-
-		self::fnNotFound();
+		//self::fnNotFound($fn);
 
 	}
 

--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -36,7 +36,7 @@ final class Guest extends Access {
 
 		}
 
-		self::fnNotFound();
+		self::fnNotFound($fn);
 
 	}
 

--- a/php/MyCLabs/Enum.php
+++ b/php/MyCLabs/Enum.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * @link    http://github.com/myclabs/php-enum
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace MyCLabs\Enum;
+
+/**
+ * Base Enum class
+ *
+ * Create an enum by implementing this class and adding class constants.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Daniel Costa <danielcosta@gmail.com>
+ * @author Mirosław Filip <mirfilip@gmail.com>
+ */
+abstract class Enum
+{
+    /**
+     * Enum value
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * Store existing constants in a static cache per object.
+     *
+     * @var array
+     */
+    protected static $cache = array();
+
+    /**
+     * Creates a new value of some type
+     *
+     * @param mixed $value
+     *
+     * @throws \UnexpectedValueException if incompatible type is given.
+     */
+    public function __construct($value)
+    {
+        if (!$this->isValid($value)) {
+            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . get_called_class());
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Returns the enum key (i.e. the constant name).
+     *
+     * @return mixed
+     */
+    public function getKey()
+    {
+        return static::search($this->value);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string)$this->value;
+    }
+
+    /**
+     * Compares one Enum with another.
+     *
+     * This method is final, for more information read https://github.com/myclabs/php-enum/issues/4
+     *
+     * @return bool True if Enums are equal, false if not equal
+     */
+    final public function equals(Enum $enum)
+    {
+        return $this->getValue() === $enum->getValue() && get_called_class() == get_class($enum);
+    }
+
+    /**
+     * Returns the names (keys) of all constants in the Enum class
+     *
+     * @return array
+     */
+    public static function keys()
+    {
+        return array_keys(static::toArray());
+    }
+
+    /**
+     * Returns instances of the Enum class of all Enum constants
+     *
+     * @return static[] Constant name in key, Enum instance in value
+     */
+    public static function values()
+    {
+        $values = array();
+
+        foreach (static::toArray() as $key => $value) {
+            $values[$key] = new static($value);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Returns all possible values as an array
+     *
+     * @return array Constant name in key, constant value in value
+     */
+    public static function toArray()
+    {
+        $class = get_called_class();
+        if (!array_key_exists($class, static::$cache)) {
+            $reflection            = new \ReflectionClass($class);
+            static::$cache[$class] = $reflection->getConstants();
+        }
+
+        return static::$cache[$class];
+    }
+
+    /**
+     * Check if is valid enum value
+     *
+     * @param $value
+     *
+     * @return bool
+     */
+    public static function isValid($value)
+    {
+        return in_array($value, static::toArray(), true);
+    }
+
+    /**
+     * Check if is valid enum key
+     *
+     * @param $key
+     *
+     * @return bool
+     */
+    public static function isValidKey($key)
+    {
+        $array = static::toArray();
+
+        return isset($array[$key]);
+    }
+
+    /**
+     * Return key for value
+     *
+     * @param $value
+     *
+     * @return mixed
+     */
+    public static function search($value)
+    {
+        return array_search($value, static::toArray(), true);
+    }
+
+    /**
+     * Returns a value when called statically like so: MyEnum::SOME_VALUE() given SOME_VALUE is a class constant
+     *
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return static
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        $array = static::toArray();
+        if (isset($array[$name])) {
+            return new static($array[$name]);
+        }
+
+        throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());
+    }
+}
+

--- a/php/Psr/Http/Message/StreamInterface.php
+++ b/php/Psr/Http/Message/StreamInterface.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Describes a data stream.
+ *
+ * Typically, an instance will wrap a PHP stream; this interface provides
+ * a wrapper around the most common operations, including serialization of
+ * the entire stream to a string.
+ */
+interface StreamInterface
+{
+    /**
+     * Reads all data from the stream into a string, from the beginning to end.
+     *
+     * This method MUST attempt to seek to the beginning of the stream before
+     * reading data and read the stream until the end is reached.
+     *
+     * Warning: This could attempt to load a large amount of data into memory.
+     *
+     * This method MUST NOT raise an exception in order to conform with PHP's
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * Closes the stream and any underlying resources.
+     *
+     * @return void
+     */
+    public function close();
+
+    /**
+     * Separates any underlying resources from the stream.
+     *
+     * After the stream has been detached, the stream is in an unusable state.
+     *
+     * @return resource|null Underlying PHP stream, if any
+     */
+    public function detach();
+
+    /**
+     * Get the size of the stream if known.
+     *
+     * @return int|null Returns the size in bytes if known, or null if unknown.
+     */
+    public function getSize();
+
+    /**
+     * Returns the current position of the file read/write pointer
+     *
+     * @return int Position of the file pointer
+     * @throws \RuntimeException on error.
+     */
+    public function tell();
+
+    /**
+     * Returns true if the stream is at the end of the stream.
+     *
+     * @return bool
+     */
+    public function eof();
+
+    /**
+     * Returns whether or not the stream is seekable.
+     *
+     * @return bool
+     */
+    public function isSeekable();
+
+    /**
+     * Seek to a position in the stream.
+     *
+     * @link http://www.php.net/manual/en/function.fseek.php
+     * @param int $offset Stream offset
+     * @param int $whence Specifies how the cursor position will be calculated
+     *     based on the seek offset. Valid values are identical to the built-in
+     *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
+     *     offset bytes SEEK_CUR: Set position to current location plus offset
+     *     SEEK_END: Set position to end-of-stream plus offset.
+     * @throws \RuntimeException on failure.
+     */
+    public function seek($offset, $whence = SEEK_SET);
+
+    /**
+     * Seek to the beginning of the stream.
+     *
+     * If the stream is not seekable, this method will raise an exception;
+     * otherwise, it will perform a seek(0).
+     *
+     * @see seek()
+     * @link http://www.php.net/manual/en/function.fseek.php
+     * @throws \RuntimeException on failure.
+     */
+    public function rewind();
+
+    /**
+     * Returns whether or not the stream is writable.
+     *
+     * @return bool
+     */
+    public function isWritable();
+
+    /**
+     * Write data to the stream.
+     *
+     * @param string $string The string that is to be written.
+     * @return int Returns the number of bytes written to the stream.
+     * @throws \RuntimeException on failure.
+     */
+    public function write($string);
+
+    /**
+     * Returns whether or not the stream is readable.
+     *
+     * @return bool
+     */
+    public function isReadable();
+
+    /**
+     * Read data from the stream.
+     *
+     * @param int $length Read up to $length bytes from the object and return
+     *     them. Fewer than $length bytes may be returned if underlying stream
+     *     call returns fewer bytes.
+     * @return string Returns the data read from the stream, or an empty string
+     *     if no bytes are available.
+     * @throws \RuntimeException if an error occurs.
+     */
+    public function read($length);
+
+    /**
+     * Returns the remaining contents in a string
+     *
+     * @return string
+     * @throws \RuntimeException if unable to read or an error occurs while
+     *     reading.
+     */
+    public function getContents();
+
+    /**
+     * Get stream metadata as an associative array or retrieve a specific key.
+     *
+     * The keys returned are identical to the keys returned from PHP's
+     * stream_get_meta_data() function.
+     *
+     * @link http://php.net/manual/en/function.stream-get-meta-data.php
+     * @param string $key Specific metadata to retrieve.
+     * @return array|mixed|null Returns an associative array if no key is
+     *     provided. Returns a specific key value if a key is provided and the
+     *     value is found, or null if the key is not found.
+     */
+    public function getMetadata($key = null);
+}

--- a/php/Psr/MessageInterface.php
+++ b/php/Psr/MessageInterface.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * HTTP messages consist of requests from a client to a server and responses
+ * from a server to a client. This interface defines the methods common to
+ * each.
+ *
+ * Messages are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return an instance that contains the changed state.
+ *
+ * @link http://www.ietf.org/rfc/rfc7230.txt
+ * @link http://www.ietf.org/rfc/rfc7231.txt
+ */
+interface MessageInterface
+{
+    /**
+     * Retrieves the HTTP protocol version as a string.
+     *
+     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion();
+
+    /**
+     * Return an instance with the specified HTTP protocol version.
+     *
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new protocol version.
+     *
+     * @param string $version HTTP protocol version
+     * @return static
+     */
+    public function withProtocolVersion($version);
+
+    /**
+     * Retrieves all message header values.
+     *
+     * The keys represent the header name as it will be sent over the wire, and
+     * each value is an array of strings associated with the header.
+     *
+     *     // Represent the headers as a string
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         echo $name . ": " . implode(", ", $values);
+     *     }
+     *
+     *     // Emit headers iteratively:
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         foreach ($values as $value) {
+     *             header(sprintf('%s: %s', $name, $value), false);
+     *         }
+     *     }
+     *
+     * While header names are not case-sensitive, getHeaders() will preserve the
+     * exact case in which headers were originally specified.
+     *
+     * @return string[][] Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings
+     *     for that header.
+     */
+    public function getHeaders();
+
+    /**
+     * Checks if a header exists by the given case-insensitive name.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return bool Returns true if any header names match the given header
+     *     name using a case-insensitive string comparison. Returns false if
+     *     no matching header name is found in the message.
+     */
+    public function hasHeader($name);
+
+    /**
+     * Retrieves a message header value by the given case-insensitive name.
+     *
+     * This method returns an array of all the header values of the given
+     * case-insensitive header name.
+     *
+     * If the header does not appear in the message, this method MUST return an
+     * empty array.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
+     */
+    public function getHeader($name);
+
+    /**
+     * Retrieves a comma-separated string of the values for a single header.
+     *
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
+     *
+     * NOTE: Not all header values may be appropriately represented using
+     * comma concatenation. For such headers, use getHeader() instead
+     * and supply your own delimiter when concatenating.
+     *
+     * If the header does not appear in the message, this method MUST return
+     * an empty string.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return an empty string.
+     */
+    public function getHeaderLine($name);
+
+    /**
+     * Return an instance with the provided value replacing the specified header.
+     *
+     * While header names are case-insensitive, the casing of the header will
+     * be preserved by this function, and returned from getHeaders().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new and/or updated header and value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withHeader($name, $value);
+
+    /**
+     * Return an instance with the specified header appended with the given value.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list. If the header did not
+     * exist previously, it will be added.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new header and/or value.
+     *
+     * @param string $name Case-insensitive header field name to add.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withAddedHeader($name, $value);
+
+    /**
+     * Return an instance without the specified header.
+     *
+     * Header resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that removes
+     * the named header.
+     *
+     * @param string $name Case-insensitive header field name to remove.
+     * @return static
+     */
+    public function withoutHeader($name);
+
+    /**
+     * Gets the body of the message.
+     *
+     * @return StreamInterface Returns the body as a stream.
+     */
+    public function getBody();
+
+    /**
+     * Return an instance with the specified message body.
+     *
+     * The body MUST be a StreamInterface object.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new body stream.
+     *
+     * @param StreamInterface $body Body.
+     * @return static
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function withBody(StreamInterface $body);
+}

--- a/php/Psr/RequestInterface.php
+++ b/php/Psr/RequestInterface.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an outgoing, client-side request.
+ *
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
+ *
+ * - Protocol version
+ * - HTTP method
+ * - URI
+ * - Headers
+ * - Message body
+ *
+ * During construction, implementations MUST attempt to set the Host header from
+ * a provided URI if no Host header is provided.
+ *
+ * Requests are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return an instance that contains the changed state.
+ */
+interface RequestInterface extends MessageInterface
+{
+    /**
+     * Retrieves the message's request target.
+     *
+     * Retrieves the message's request-target either as it will appear (for
+     * clients), as it appeared at request (for servers), or as it was
+     * specified for the instance (see withRequestTarget()).
+     *
+     * In most cases, this will be the origin-form of the composed URI,
+     * unless a value was provided to the concrete implementation (see
+     * withRequestTarget() below).
+     *
+     * If no URI is available, and no request-target has been specifically
+     * provided, this method MUST return the string "/".
+     *
+     * @return string
+     */
+    public function getRequestTarget();
+
+    /**
+     * Return an instance with the specific request-target.
+     *
+     * If the request needs a non-origin-form request-target — e.g., for
+     * specifying an absolute-form, authority-form, or asterisk-form —
+     * this method may be used to create an instance with the specified
+     * request-target, verbatim.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * changed request target.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
+     *     request-target forms allowed in request messages)
+     * @param mixed $requestTarget
+     * @return static
+     */
+    public function withRequestTarget($requestTarget);
+
+    /**
+     * Retrieves the HTTP method of the request.
+     *
+     * @return string Returns the request method.
+     */
+    public function getMethod();
+
+    /**
+     * Return an instance with the provided HTTP method.
+     *
+     * While HTTP method names are typically all uppercase characters, HTTP
+     * method names are case-sensitive and thus implementations SHOULD NOT
+     * modify the given string.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * changed request method.
+     *
+     * @param string $method Case-sensitive method.
+     * @return static
+     * @throws \InvalidArgumentException for invalid HTTP methods.
+     */
+    public function withMethod($method);
+
+    /**
+     * Retrieves the URI instance.
+     *
+     * This method MUST return a UriInterface instance.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @return UriInterface Returns a UriInterface instance
+     *     representing the URI of the request.
+     */
+    public function getUri();
+
+    /**
+     * Returns an instance with the provided URI.
+     *
+     * This method MUST update the Host header of the returned request by
+     * default if the URI contains a host component. If the URI does not
+     * contain a host component, any pre-existing Host header MUST be carried
+     * over to the returned request.
+     *
+     * You can opt-in to preserving the original state of the Host header by
+     * setting `$preserveHost` to `true`. When `$preserveHost` is set to
+     * `true`, this method interacts with the Host header in the following ways:
+     *
+     * - If the Host header is missing or empty, and the new URI contains
+     *   a host component, this method MUST update the Host header in the returned
+     *   request.
+     * - If the Host header is missing or empty, and the new URI does not contain a
+     *   host component, this method MUST NOT update the Host header in the returned
+     *   request.
+     * - If a Host header is present and non-empty, this method MUST NOT update
+     *   the Host header in the returned request.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new UriInterface instance.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @param UriInterface $uri New request URI to use.
+     * @param bool $preserveHost Preserve the original state of the Host header.
+     * @return static
+     */
+    public function withUri(UriInterface $uri, $preserveHost = false);
+}

--- a/php/Psr/ResponseInterface.php
+++ b/php/Psr/ResponseInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an outgoing, server-side response.
+ *
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
+ *
+ * - Protocol version
+ * - Status code and reason phrase
+ * - Headers
+ * - Message body
+ *
+ * Responses are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return an instance that contains the changed state.
+ */
+interface ResponseInterface extends MessageInterface
+{
+    /**
+     * Gets the response status code.
+     *
+     * The status code is a 3-digit integer result code of the server's attempt
+     * to understand and satisfy the request.
+     *
+     * @return int Status code.
+     */
+    public function getStatusCode();
+
+    /**
+     * Return an instance with the specified status code and, optionally, reason phrase.
+     *
+     * If no reason phrase is specified, implementations MAY choose to default
+     * to the RFC 7231 or IANA recommended reason phrase for the response's
+     * status code.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated status and reason phrase.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @param int $code The 3-digit integer result code to set.
+     * @param string $reasonPhrase The reason phrase to use with the
+     *     provided status code; if none is provided, implementations MAY
+     *     use the defaults as suggested in the HTTP specification.
+     * @return static
+     * @throws \InvalidArgumentException For invalid status code arguments.
+     */
+    public function withStatus($code, $reasonPhrase = '');
+
+    /**
+     * Gets the response reason phrase associated with the status code.
+     *
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
+     * choose to return the default RFC 7231 recommended reason phrase (or those
+     * listed in the IANA HTTP Status Code Registry) for the response's
+     * status code.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @return string Reason phrase; must return an empty string if none present.
+     */
+    public function getReasonPhrase();
+}

--- a/php/Psr/ServerRequestInterface.php
+++ b/php/Psr/ServerRequestInterface.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an incoming, server-side HTTP request.
+ *
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
+ *
+ * - Protocol version
+ * - HTTP method
+ * - URI
+ * - Headers
+ * - Message body
+ *
+ * Additionally, it encapsulates all data as it has arrived to the
+ * application from the CGI and/or PHP environment, including:
+ *
+ * - The values represented in $_SERVER.
+ * - Any cookies provided (generally via $_COOKIE)
+ * - Query string arguments (generally via $_GET, or as parsed via parse_str())
+ * - Upload files, if any (as represented by $_FILES)
+ * - Deserialized body parameters (generally from $_POST)
+ *
+ * $_SERVER values MUST be treated as immutable, as they represent application
+ * state at the time of request; as such, no methods are provided to allow
+ * modification of those values. The other values provide such methods, as they
+ * can be restored from $_SERVER or the request body, and may need treatment
+ * during the application (e.g., body parameters may be deserialized based on
+ * content type).
+ *
+ * Additionally, this interface recognizes the utility of introspecting a
+ * request to derive and match additional parameters (e.g., via URI path
+ * matching, decrypting cookie values, deserializing non-form-encoded body
+ * content, matching authorization headers to users, etc). These parameters
+ * are stored in an "attributes" property.
+ *
+ * Requests are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return an instance that contains the changed state.
+ */
+interface ServerRequestInterface extends RequestInterface
+{
+    /**
+     * Retrieve server parameters.
+     *
+     * Retrieves data related to the incoming request environment,
+     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
+     * REQUIRED to originate from $_SERVER.
+     *
+     * @return array
+     */
+    public function getServerParams();
+
+    /**
+     * Retrieve cookies.
+     *
+     * Retrieves cookies sent by the client to the server.
+     *
+     * The data MUST be compatible with the structure of the $_COOKIE
+     * superglobal.
+     *
+     * @return array
+     */
+    public function getCookieParams();
+
+    /**
+     * Return an instance with the specified cookies.
+     *
+     * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
+     * be compatible with the structure of $_COOKIE. Typically, this data will
+     * be injected at instantiation.
+     *
+     * This method MUST NOT update the related Cookie header of the request
+     * instance, nor related values in the server params.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated cookie values.
+     *
+     * @param array $cookies Array of key/value pairs representing cookies.
+     * @return static
+     */
+    public function withCookieParams(array $cookies);
+
+    /**
+     * Retrieve query string arguments.
+     *
+     * Retrieves the deserialized query string arguments, if any.
+     *
+     * Note: the query params might not be in sync with the URI or server
+     * params. If you need to ensure you are only getting the original
+     * values, you may need to parse the query string from `getUri()->getQuery()`
+     * or from the `QUERY_STRING` server param.
+     *
+     * @return array
+     */
+    public function getQueryParams();
+
+    /**
+     * Return an instance with the specified query string arguments.
+     *
+     * These values SHOULD remain immutable over the course of the incoming
+     * request. They MAY be injected during instantiation, such as from PHP's
+     * $_GET superglobal, or MAY be derived from some other value such as the
+     * URI. In cases where the arguments are parsed from the URI, the data
+     * MUST be compatible with what PHP's parse_str() would return for
+     * purposes of how duplicate query parameters are handled, and how nested
+     * sets are handled.
+     *
+     * Setting query string arguments MUST NOT change the URI stored by the
+     * request, nor the values in the server params.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated query string arguments.
+     *
+     * @param array $query Array of query string arguments, typically from
+     *     $_GET.
+     * @return static
+     */
+    public function withQueryParams(array $query);
+
+    /**
+     * Retrieve normalized file upload data.
+     *
+     * This method returns upload metadata in a normalized tree, with each leaf
+     * an instance of Psr\Http\Message\UploadedFileInterface.
+     *
+     * These values MAY be prepared from $_FILES or the message body during
+     * instantiation, or MAY be injected via withUploadedFiles().
+     *
+     * @return array An array tree of UploadedFileInterface instances; an empty
+     *     array MUST be returned if no data is present.
+     */
+    public function getUploadedFiles();
+
+    /**
+     * Create a new instance with the specified uploaded files.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated body parameters.
+     *
+     * @param array $uploadedFiles An array tree of UploadedFileInterface instances.
+     * @return static
+     * @throws \InvalidArgumentException if an invalid structure is provided.
+     */
+    public function withUploadedFiles(array $uploadedFiles);
+
+    /**
+     * Retrieve any parameters provided in the request body.
+     *
+     * If the request Content-Type is either application/x-www-form-urlencoded
+     * or multipart/form-data, and the request method is POST, this method MUST
+     * return the contents of $_POST.
+     *
+     * Otherwise, this method may return any results of deserializing
+     * the request body content; as parsing returns structured content, the
+     * potential types MUST be arrays or objects only. A null value indicates
+     * the absence of body content.
+     *
+     * @return null|array|object The deserialized body parameters, if any.
+     *     These will typically be an array or object.
+     */
+    public function getParsedBody();
+
+    /**
+     * Return an instance with the specified body parameters.
+     *
+     * These MAY be injected during instantiation.
+     *
+     * If the request Content-Type is either application/x-www-form-urlencoded
+     * or multipart/form-data, and the request method is POST, use this method
+     * ONLY to inject the contents of $_POST.
+     *
+     * The data IS NOT REQUIRED to come from $_POST, but MUST be the results of
+     * deserializing the request body content. Deserialization/parsing returns
+     * structured data, and, as such, this method ONLY accepts arrays or objects,
+     * or a null value if nothing was available to parse.
+     *
+     * As an example, if content negotiation determines that the request data
+     * is a JSON payload, this method could be used to create a request
+     * instance with the deserialized parameters.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated body parameters.
+     *
+     * @param null|array|object $data The deserialized body data. This will
+     *     typically be in an array or object.
+     * @return static
+     * @throws \InvalidArgumentException if an unsupported argument type is
+     *     provided.
+     */
+    public function withParsedBody($data);
+
+    /**
+     * Retrieve attributes derived from the request.
+     *
+     * The request "attributes" may be used to allow injection of any
+     * parameters derived from the request: e.g., the results of path
+     * match operations; the results of decrypting cookies; the results of
+     * deserializing non-form-encoded message bodies; etc. Attributes
+     * will be application and request specific, and CAN be mutable.
+     *
+     * @return array Attributes derived from the request.
+     */
+    public function getAttributes();
+
+    /**
+     * Retrieve a single derived request attribute.
+     *
+     * Retrieves a single derived request attribute as described in
+     * getAttributes(). If the attribute has not been previously set, returns
+     * the default value as provided.
+     *
+     * This method obviates the need for a hasAttribute() method, as it allows
+     * specifying a default value to return if the attribute is not found.
+     *
+     * @see getAttributes()
+     * @param string $name The attribute name.
+     * @param mixed $default Default value to return if the attribute does not exist.
+     * @return mixed
+     */
+    public function getAttribute($name, $default = null);
+
+    /**
+     * Return an instance with the specified derived request attribute.
+     *
+     * This method allows setting a single derived request attribute as
+     * described in getAttributes().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated attribute.
+     *
+     * @see getAttributes()
+     * @param string $name The attribute name.
+     * @param mixed $value The value of the attribute.
+     * @return static
+     */
+    public function withAttribute($name, $value);
+
+    /**
+     * Return an instance that removes the specified derived request attribute.
+     *
+     * This method allows removing a single derived request attribute as
+     * described in getAttributes().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that removes
+     * the attribute.
+     *
+     * @see getAttributes()
+     * @param string $name The attribute name.
+     * @return static
+     */
+    public function withoutAttribute($name);
+}

--- a/php/Psr/UploadedFileInterface.php
+++ b/php/Psr/UploadedFileInterface.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a file uploaded through an HTTP request.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return an instance that contains the
+ * changed state.
+ */
+interface UploadedFileInterface
+{
+    /**
+     * Retrieve a stream representing the uploaded file.
+     *
+     * This method MUST return a StreamInterface instance, representing the
+     * uploaded file. The purpose of this method is to allow utilizing native PHP
+     * stream functionality to manipulate the file upload, such as
+     * stream_copy_to_stream() (though the result will need to be decorated in a
+     * native PHP stream wrapper to work with such functions).
+     *
+     * If the moveTo() method has been called previously, this method MUST raise
+     * an exception.
+     *
+     * @return StreamInterface Stream representation of the uploaded file.
+     * @throws \RuntimeException in cases when no stream is available or can be
+     *     created.
+     */
+    public function getStream();
+
+    /**
+     * Move the uploaded file to a new location.
+     *
+     * Use this method as an alternative to move_uploaded_file(). This method is
+     * guaranteed to work in both SAPI and non-SAPI environments.
+     * Implementations must determine which environment they are in, and use the
+     * appropriate method (move_uploaded_file(), rename(), or a stream
+     * operation) to perform the operation.
+     *
+     * $targetPath may be an absolute path, or a relative path. If it is a
+     * relative path, resolution should be the same as used by PHP's rename()
+     * function.
+     *
+     * The original file or stream MUST be removed on completion.
+     *
+     * If this method is called more than once, any subsequent calls MUST raise
+     * an exception.
+     *
+     * When used in an SAPI environment where $_FILES is populated, when writing
+     * files via moveTo(), is_uploaded_file() and move_uploaded_file() SHOULD be
+     * used to ensure permissions and upload status are verified correctly.
+     *
+     * If you wish to move to a stream, use getStream(), as SAPI operations
+     * cannot guarantee writing to stream destinations.
+     *
+     * @see http://php.net/is_uploaded_file
+     * @see http://php.net/move_uploaded_file
+     * @param string $targetPath Path to which to move the uploaded file.
+     * @throws \InvalidArgumentException if the $targetPath specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
+     *     the second or subsequent call to the method.
+     */
+    public function moveTo($targetPath);
+    
+    /**
+     * Retrieve the file size.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array if available, as PHP calculates this based
+     * on the actual size transmitted.
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize();
+    
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
+     *
+     * If the file was uploaded successfully, this method MUST return
+     * UPLOAD_ERR_OK.
+     *
+     * Implementations SHOULD return the value stored in the "error" key of
+     * the file in the $_FILES array.
+     *
+     * @see http://php.net/manual/en/features.file-upload.errors.php
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
+     */
+    public function getError();
+    
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious filename with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "name" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename();
+    
+    /**
+     * Retrieve the media type sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious media type with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "type" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The media type sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientMediaType();
+}

--- a/php/Psr/UriInterface.php
+++ b/php/Psr/UriInterface.php
@@ -1,0 +1,323 @@
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a URI.
+ *
+ * This interface is meant to represent URIs according to RFC 3986 and to
+ * provide methods for most common operations. Additional functionality for
+ * working with URIs can be provided on top of the interface or externally.
+ * Its primary use is for HTTP requests, but may also be used in other
+ * contexts.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return an instance that contains the
+ * changed state.
+ *
+ * Typically the Host header will be also be present in the request message.
+ * For server-side requests, the scheme will typically be discoverable in the
+ * server parameters.
+ *
+ * @link http://tools.ietf.org/html/rfc3986 (the URI specification)
+ */
+interface UriInterface
+{
+    /**
+     * Retrieve the scheme component of the URI.
+     *
+     * If no scheme is present, this method MUST return an empty string.
+     *
+     * The value returned MUST be normalized to lowercase, per RFC 3986
+     * Section 3.1.
+     *
+     * The trailing ":" character is not part of the scheme and MUST NOT be
+     * added.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-3.1
+     * @return string The URI scheme.
+     */
+    public function getScheme();
+
+    /**
+     * Retrieve the authority component of the URI.
+     *
+     * If no authority information is present, this method MUST return an empty
+     * string.
+     *
+     * The authority syntax of the URI is:
+     *
+     * <pre>
+     * [user-info@]host[:port]
+     * </pre>
+     *
+     * If the port component is not set or is the standard port for the current
+     * scheme, it SHOULD NOT be included.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-3.2
+     * @return string The URI authority, in "[user-info@]host[:port]" format.
+     */
+    public function getAuthority();
+
+    /**
+     * Retrieve the user information component of the URI.
+     *
+     * If no user information is present, this method MUST return an empty
+     * string.
+     *
+     * If a user is present in the URI, this will return that value;
+     * additionally, if the password is also present, it will be appended to the
+     * user value, with a colon (":") separating the values.
+     *
+     * The trailing "@" character is not part of the user information and MUST
+     * NOT be added.
+     *
+     * @return string The URI user information, in "username[:password]" format.
+     */
+    public function getUserInfo();
+
+    /**
+     * Retrieve the host component of the URI.
+     *
+     * If no host is present, this method MUST return an empty string.
+     *
+     * The value returned MUST be normalized to lowercase, per RFC 3986
+     * Section 3.2.2.
+     *
+     * @see http://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @return string The URI host.
+     */
+    public function getHost();
+
+    /**
+     * Retrieve the port component of the URI.
+     *
+     * If a port is present, and it is non-standard for the current scheme,
+     * this method MUST return it as an integer. If the port is the standard port
+     * used with the current scheme, this method SHOULD return null.
+     *
+     * If no port is present, and no scheme is present, this method MUST return
+     * a null value.
+     *
+     * If no port is present, but a scheme is present, this method MAY return
+     * the standard port for that scheme, but SHOULD return null.
+     *
+     * @return null|int The URI port.
+     */
+    public function getPort();
+
+    /**
+     * Retrieve the path component of the URI.
+     *
+     * The path can either be empty or absolute (starting with a slash) or
+     * rootless (not starting with a slash). Implementations MUST support all
+     * three syntaxes.
+     *
+     * Normally, the empty path "" and absolute path "/" are considered equal as
+     * defined in RFC 7230 Section 2.7.3. But this method MUST NOT automatically
+     * do this normalization because in contexts with a trimmed base path, e.g.
+     * the front controller, this difference becomes significant. It's the task
+     * of the user to handle both "" and "/".
+     *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.3.
+     *
+     * As an example, if the value should include a slash ("/") not intended as
+     * delimiter between path segments, that value MUST be passed in encoded
+     * form (e.g., "%2F") to the instance.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.3
+     * @return string The URI path.
+     */
+    public function getPath();
+
+    /**
+     * Retrieve the query string of the URI.
+     *
+     * If no query string is present, this method MUST return an empty string.
+     *
+     * The leading "?" character is not part of the query and MUST NOT be
+     * added.
+     *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.4.
+     *
+     * As an example, if a value in a key/value pair of the query string should
+     * include an ampersand ("&") not intended as a delimiter between values,
+     * that value MUST be passed in encoded form (e.g., "%26") to the instance.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.4
+     * @return string The URI query string.
+     */
+    public function getQuery();
+
+    /**
+     * Retrieve the fragment component of the URI.
+     *
+     * If no fragment is present, this method MUST return an empty string.
+     *
+     * The leading "#" character is not part of the fragment and MUST NOT be
+     * added.
+     *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.5.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.5
+     * @return string The URI fragment.
+     */
+    public function getFragment();
+
+    /**
+     * Return an instance with the specified scheme.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified scheme.
+     *
+     * Implementations MUST support the schemes "http" and "https" case
+     * insensitively, and MAY accommodate other schemes if required.
+     *
+     * An empty scheme is equivalent to removing the scheme.
+     *
+     * @param string $scheme The scheme to use with the new instance.
+     * @return static A new instance with the specified scheme.
+     * @throws \InvalidArgumentException for invalid or unsupported schemes.
+     */
+    public function withScheme($scheme);
+
+    /**
+     * Return an instance with the specified user information.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified user information.
+     *
+     * Password is optional, but the user information MUST include the
+     * user; an empty string for the user is equivalent to removing user
+     * information.
+     *
+     * @param string $user The user name to use for authority.
+     * @param null|string $password The password associated with $user.
+     * @return static A new instance with the specified user information.
+     */
+    public function withUserInfo($user, $password = null);
+
+    /**
+     * Return an instance with the specified host.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified host.
+     *
+     * An empty host value is equivalent to removing the host.
+     *
+     * @param string $host The hostname to use with the new instance.
+     * @return static A new instance with the specified host.
+     * @throws \InvalidArgumentException for invalid hostnames.
+     */
+    public function withHost($host);
+
+    /**
+     * Return an instance with the specified port.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified port.
+     *
+     * Implementations MUST raise an exception for ports outside the
+     * established TCP and UDP port ranges.
+     *
+     * A null value provided for the port is equivalent to removing the port
+     * information.
+     *
+     * @param null|int $port The port to use with the new instance; a null value
+     *     removes the port information.
+     * @return static A new instance with the specified port.
+     * @throws \InvalidArgumentException for invalid ports.
+     */
+    public function withPort($port);
+
+    /**
+     * Return an instance with the specified path.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified path.
+     *
+     * The path can either be empty or absolute (starting with a slash) or
+     * rootless (not starting with a slash). Implementations MUST support all
+     * three syntaxes.
+     *
+     * If the path is intended to be domain-relative rather than path relative then
+     * it must begin with a slash ("/"). Paths not starting with a slash ("/")
+     * are assumed to be relative to some base path known to the application or
+     * consumer.
+     *
+     * Users can provide both encoded and decoded path characters.
+     * Implementations ensure the correct encoding as outlined in getPath().
+     *
+     * @param string $path The path to use with the new instance.
+     * @return static A new instance with the specified path.
+     * @throws \InvalidArgumentException for invalid paths.
+     */
+    public function withPath($path);
+
+    /**
+     * Return an instance with the specified query string.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified query string.
+     *
+     * Users can provide both encoded and decoded query characters.
+     * Implementations ensure the correct encoding as outlined in getQuery().
+     *
+     * An empty query string value is equivalent to removing the query string.
+     *
+     * @param string $query The query string to use with the new instance.
+     * @return static A new instance with the specified query string.
+     * @throws \InvalidArgumentException for invalid query strings.
+     */
+    public function withQuery($query);
+
+    /**
+     * Return an instance with the specified URI fragment.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified URI fragment.
+     *
+     * Users can provide both encoded and decoded fragment characters.
+     * Implementations ensure the correct encoding as outlined in getFragment().
+     *
+     * An empty fragment value is equivalent to removing the fragment.
+     *
+     * @param string $fragment The fragment to use with the new instance.
+     * @return static A new instance with the specified fragment.
+     */
+    public function withFragment($fragment);
+
+    /**
+     * Return the string representation as a URI reference.
+     *
+     * Depending on which components of the URI are present, the resulting
+     * string is either a full URI or relative reference according to RFC 3986,
+     * Section 4.1. The method concatenates the various components of the URI,
+     * using the appropriate delimiters:
+     *
+     * - If a scheme is present, it MUST be suffixed by ":".
+     * - If an authority is present, it MUST be prefixed by "//".
+     * - The path can be concatenated without delimiters. But there are two
+     *   cases where the path has to be adjusted to make the URI reference
+     *   valid as PHP does not allow to throw an exception in __toString():
+     *     - If the path is rootless and an authority is present, the path MUST
+     *       be prefixed by "/".
+     *     - If the path is starting with more than one "/" and no authority is
+     *       present, the starting slashes MUST be reduced to one.
+     * - If a query is present, it MUST be prefixed by "?".
+     * - If a fragment is present, it MUST be prefixed by "#".
+     *
+     * @see http://tools.ietf.org/html/rfc3986#section-4.1
+     * @return string
+     */
+    public function __toString();
+}

--- a/php/ZipStream/Bigint.php
+++ b/php/ZipStream/Bigint.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+use OverflowException;
+
+class Bigint
+{
+    private $bytes = [0, 0, 0, 0, 0, 0, 0, 0];
+
+    public function __construct(int $value = 0)
+    {
+        if ($value instanceof self) {
+            $this->bytes = $value->bytes;
+        } else {
+            $this->fillBytes($value, 0, 8);
+        }
+    }
+
+    protected function fillBytes(int $value, int $start, int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->bytes[$start + $i] = $i >= PHP_INT_SIZE ? 0 : $value & 0xFF;
+            $value >>= 8;
+        }
+    }
+
+    public static function init(int $value = 0): self
+    {
+        return new self($value);
+    }
+
+    public static function fromLowHigh(int $low, int $high): self
+    {
+        $bigint = new Bigint;
+        $bigint->fillBytes($low, 0, 4);
+        $bigint->fillBytes($high, 4, 4);
+        return $bigint;
+    }
+
+    public function getHigh32(): int
+    {
+        return $this->getValue(4, 4);
+    }
+
+    public function getValue(int $end = 0, int $length = 8): int
+    {
+        $result = 0;
+        for ($i = $end + $length - 1; $i >= $end; $i--) {
+            $result <<= 8;
+            $result |= $this->bytes[$i];
+        }
+        return $result;
+    }
+
+    public function getLowFF(bool $force = false): int
+    {
+        if ($force || $this->isOver32()) {
+            return 0xFFFFFFFF;
+        }
+        return $this->getLow32();
+    }
+
+    public function isOver32(bool $force = false): bool
+    {
+        // value 0xFFFFFFFF already needs a Zip64 header
+        return $force ||
+            max(array_slice($this->bytes, 4, 4)) > 0 ||
+            min(array_slice($this->bytes, 0, 4)) === 0xFF;
+    }
+
+    public function getLow32(): int
+    {
+        return $this->getValue(0, 4);
+    }
+
+    public function getHex64(): string
+    {
+        $result = '0x';
+        for ($i = 7; $i >= 0; $i--) {
+            $result .= sprintf('%02X', $this->bytes[$i]);
+        }
+        return $result;
+    }
+
+    public function add(self $other): self
+    {
+        $result = clone $this;
+        $overflow = false;
+        for ($i = 0; $i < 8; $i++) {
+            $result->bytes[$i] += $other->bytes[$i];
+            if ($overflow) {
+                $result->bytes[$i]++;
+                $overflow = false;
+            }
+            if ($result->bytes[$i] & 0x100) {
+                $overflow = true;
+                $result->bytes[$i] &= 0xFF;
+            }
+        }
+        if ($overflow) {
+            throw new OverflowException;
+        }
+        return $result;
+    }
+}

--- a/php/ZipStream/DeflateStream.php
+++ b/php/ZipStream/DeflateStream.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+class DeflateStream extends Stream
+{
+    protected $filter;
+    protected $options;
+
+    public function rewind(): void
+    {
+        // deflate filter needs to be removed before rewind
+        if ($this->filter) {
+            $this->removeDeflateFilter();
+            $this->seek(0);
+            $this->addDeflateFilter($this->options);
+        } else {
+            rewind($this->stream);
+        }
+    }
+
+    public function removeDeflateFilter(): void
+    {
+        if (!$this->filter) {
+            return;
+        }
+        stream_filter_remove($this->filter);
+        $this->filter = null;
+    }
+
+    public function addDeflateFilter(array $options = null): void
+    {
+        $this->options = $options;
+        $this->filter = stream_filter_append(
+            $this->stream,
+            'zlib.deflate',
+            STREAM_FILTER_READ,
+            $this->options
+        );
+    }
+}

--- a/php/ZipStream/Exception.php
+++ b/php/ZipStream/Exception.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+/**
+ * This class is only for inheriting
+ */
+abstract class Exception extends \Exception
+{
+}

--- a/php/ZipStream/Exception/EncodingException.php
+++ b/php/ZipStream/Exception/EncodingException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if file or comment encoding is incorrect
+ */
+class EncodingException extends Exception
+{
+}

--- a/php/ZipStream/Exception/FileNotFoundException.php
+++ b/php/ZipStream/Exception/FileNotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if a file wasn't found
+ */
+class FileNotFoundException extends Exception
+{
+    /**
+     * Constructor of the Exception
+     *
+     * @param String $path - The path which wasn't found
+     */
+    public function __construct(string $path)
+    {
+        parent::__construct("Ths file with the path $path wasn't found.");
+    }
+}

--- a/php/ZipStream/Exception/FileNotReadableException.php
+++ b/php/ZipStream/Exception/FileNotReadableException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if a file wasn't found
+ */
+class FileNotReadableException extends Exception
+{
+    /**
+     * Constructor of the Exception
+     *
+     * @param String $path - The path which wasn't found
+     */
+    public function __construct(string $path)
+    {
+        parent::__construct("Ths file with the path $path isn't readable.");
+    }
+}

--- a/php/ZipStream/Exception/IncompatibleOptionsException.php
+++ b/php/ZipStream/Exception/IncompatibleOptionsException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if options are incompatible
+ */
+class IncompatibleOptionsException extends Exception
+{
+}

--- a/php/ZipStream/Exception/OverflowException.php
+++ b/php/ZipStream/Exception/OverflowException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if a counter value exceeds storage size
+ */
+class OverflowException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('File size exceeds limit of 32 bit integer. Please enable "zip64" option.');
+    }
+}

--- a/php/ZipStream/Exception/StreamNotReadableException.php
+++ b/php/ZipStream/Exception/StreamNotReadableException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Exception;
+
+use ZipStream\Exception;
+
+/**
+ * This Exception gets invoked if `fread` fails on a stream.
+ */
+class StreamNotReadableException extends Exception
+{
+    /**
+     * Constructor of the Exception
+     *
+     * @param string $fileName - The name of the file which the stream belongs to.
+     */
+    public function __construct(string $fileName)
+    {
+        parent::__construct("The stream for $fileName could not be read.");
+    }
+}

--- a/php/ZipStream/File.php
+++ b/php/ZipStream/File.php
@@ -1,0 +1,479 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+use Psr\Http\Message\StreamInterface;
+use ZipStream\Exception\EncodingException;
+use ZipStream\Exception\FileNotFoundException;
+use ZipStream\Exception\FileNotReadableException;
+use ZipStream\Exception\OverflowException;
+use ZipStream\Option\Archive as ArchiveOptions;
+use ZipStream\Option\File as FileOptions;
+use ZipStream\Option\Method;
+use ZipStream\Option\Version;
+
+class File
+{
+    const HASH_ALGORITHM = 'crc32b';
+
+    const BIT_ZERO_HEADER = 0x0008;
+    const BIT_EFS_UTF8 = 0x0800;
+
+    const COMPUTE = 1;
+    const SEND = 2;
+
+    private const CHUNKED_READ_BLOCK_SIZE = 1048576;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var ArchiveOptions
+     */
+    public $opt;
+
+    /**
+     * @var Bigint
+     */
+    public $len;
+    /**
+     * @var Bigint
+     */
+    public $zlen;
+
+    /** @var  int */
+    public $crc;
+
+    /**
+     * @var Bigint
+     */
+    public $hlen;
+
+    /**
+     * @var Bigint
+     */
+    public $ofs;
+
+    /**
+     * @var int
+     */
+    public $bits;
+
+    /**
+     * @var Version
+     */
+    public $version;
+
+    /**
+     * @var ZipStream
+     */
+    public $zip;
+
+    /**
+     * @var resource
+     */
+    private $deflate;
+    /**
+     * @var resource
+     */
+    private $hash;
+
+    /**
+     * @var Method
+     */
+    private $method;
+
+    /**
+     * @var Bigint
+     */
+    private $totalLength;
+
+    public function __construct(ZipStream $zip, string $name, ?FileOptions $opt = null)
+    {
+        $this->zip = $zip;
+
+        $this->name = $name;
+        $this->opt = $opt ?: new FileOptions();
+        $this->method = $this->opt->getMethod();
+        $this->version = Version::STORE();
+        $this->ofs = new Bigint;
+    }
+
+    public function processPath(string $path): void
+    {
+        if (!is_readable($path)) {
+            if (!file_exists($path)) {
+                throw new FileNotFoundException($path);
+            }
+            throw new FileNotReadableException($path);
+        }
+        if ($this->zip->isLargeFile($path) === false) {
+            $data = file_get_contents($path);
+            $this->processData($data);
+        } else {
+            $this->method = $this->zip->opt->getLargeFileMethod();
+
+            $stream = new DeflateStream(fopen($path, 'rb'));
+            $this->processStream($stream);
+        }
+    }
+
+    public function processData(string $data): void
+    {
+        $this->len = new Bigint(strlen($data));
+        $this->crc = crc32($data);
+
+        // compress data if needed
+        if ($this->method->equals(Method::DEFLATE())) {
+            $data = gzdeflate($data);
+        }
+
+        $this->zlen = new Bigint(strlen($data));
+        $this->addFileHeader();
+        $this->zip->send($data);
+        $this->addFileFooter();
+    }
+
+    /**
+     * Create and send zip header for this file.
+     *
+     * @return void
+     * @throws \ZipStream\Exception\EncodingException
+     */
+    public function addFileHeader(): void
+    {
+        $name = static::filterFilename($this->name);
+
+        // calculate name length
+        $nameLength = strlen($name);
+
+        // create dos timestamp
+        $time = static::dosTime($this->opt->getTime()->getTimestamp());
+
+        $comment = $this->opt->getComment();
+
+        if (!mb_check_encoding($name, 'ASCII') ||
+            !mb_check_encoding($comment, 'ASCII')) {
+            // Sets Bit 11: Language encoding flag (EFS).  If this bit is set,
+            // the filename and comment fields for this file
+            // MUST be encoded using UTF-8. (see APPENDIX D)
+            if (!mb_check_encoding($name, 'UTF-8') ||
+                !mb_check_encoding($comment, 'UTF-8')) {
+                throw new EncodingException(
+                    'File name and comment should use UTF-8 ' .
+                    'if one of them does not fit into ASCII range.'
+                );
+            }
+            $this->bits |= self::BIT_EFS_UTF8;
+        }
+
+        if ($this->method->equals(Method::DEFLATE())) {
+            $this->version = Version::DEFLATE();
+        }
+
+        $force = (boolean)($this->bits & self::BIT_ZERO_HEADER) &&
+            $this->zip->opt->isEnableZip64();
+
+        $footer = $this->buildZip64ExtraBlock($force);
+
+        // If this file will start over 4GB limit in ZIP file,
+        // CDR record will have to use Zip64 extension to describe offset
+        // to keep consistency we use the same value here
+        if ($this->zip->ofs->isOver32()) {
+            $this->version = Version::ZIP64();
+        }
+
+        $fields = [
+            ['V', ZipStream::FILE_HEADER_SIGNATURE],
+            ['v', $this->version->getValue()],                  // Version needed to Extract
+            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
+            ['v', $this->method->getValue()],                     // Compression method
+            ['V', $time],                           // Timestamp (DOS Format)
+            ['V', $this->crc],                      // CRC32 of data (0 -> moved to data descriptor footer)
+            ['V', $this->zlen->getLowFF($force)],   // Length of compressed data (forced to 0xFFFFFFFF for zero header)
+            ['V', $this->len->getLowFF($force)],    // Length of original data (forced to 0xFFFFFFFF for zero header)
+            ['v', $nameLength],                           // Length of filename
+            ['v', strlen($footer)],                 // Extra data (see above)
+        ];
+
+        // pack fields and calculate "total" length
+        $header = ZipStream::packFields($fields);
+
+        // print header and filename
+        $data = $header . $name . $footer;
+        $this->zip->send($data);
+
+        // save header length
+        $this->hlen = Bigint::init(strlen($data));
+    }
+
+    /**
+     * Strip characters that are not legal in Windows filenames
+     * to prevent compatibility issues
+     *
+     * @param string $filename Unprocessed filename
+     * @return string
+     */
+    public static function filterFilename(string $filename): string
+    {
+        // strip leading slashes from file name
+        // (fixes bug in windows archive viewer)
+        $filename = preg_replace('/^\\/+/', '', $filename);
+
+        return str_replace(['\\', ':', '*', '?', '"', '<', '>', '|'], '_', $filename);
+    }
+
+    /**
+     * Convert a UNIX timestamp to a DOS timestamp.
+     *
+     * @param Integer $when
+     * @return Integer DOS Timestamp
+     */
+    final protected static function dosTime(int $when): int
+    {
+        // get date array for timestamp
+        $d = getdate($when);
+
+        // set lower-bound on dates
+        if ($d['year'] < 1980) {
+            $d = array(
+                'year' => 1980,
+                'mon' => 1,
+                'mday' => 1,
+                'hours' => 0,
+                'minutes' => 0,
+                'seconds' => 0
+            );
+        }
+
+        // remove extra years from 1980
+        $d['year'] -= 1980;
+
+        // return date string
+        return
+            ($d['year'] << 25) |
+            ($d['mon'] << 21) |
+            ($d['mday'] << 16) |
+            ($d['hours'] << 11) |
+            ($d['minutes'] << 5) |
+            ($d['seconds'] >> 1);
+    }
+
+    protected function buildZip64ExtraBlock(bool $force = false): string
+    {
+
+        $fields = [];
+        if ($this->len->isOver32($force)) {
+            $fields[] = ['P', $this->len];          // Length of original data
+        }
+
+        if ($this->len->isOver32($force)) {
+            $fields[] = ['P', $this->zlen];         // Length of compressed data
+        }
+
+        if ($this->ofs->isOver32()) {
+            $fields[] = ['P', $this->ofs];          // Offset of local header record
+        }
+
+        if (!empty($fields)) {
+            if (!$this->zip->opt->isEnableZip64()) {
+                throw new OverflowException();
+            }
+
+            array_unshift(
+                $fields,
+                ['v', 0x0001],                      // 64 bit extension
+                ['v', count($fields) * 8]             // Length of data block
+            );
+            $this->version = Version::ZIP64();
+        }
+
+        return ZipStream::packFields($fields);
+    }
+
+    /**
+     * Create and send data descriptor footer for this file.
+     *
+     * @return void
+     */
+
+    public function addFileFooter(): void
+    {
+
+        if ($this->bits & self::BIT_ZERO_HEADER) {
+            $fields = [
+                ['V', ZipStream::DATA_DESCRIPTOR_SIGNATURE],
+                ['V', $this->crc],              // CRC32
+                ['V', $this->zlen],             // Length of compressed data
+                ['V', $this->len],              // Length of original data
+            ];
+
+            if ($this->zip->opt->isEnableZip64()) {
+                $fields = [
+                    ['V', ZipStream::DATA_DESCRIPTOR_SIGNATURE],
+                    ['V', $this->crc],              // CRC32
+                    ['P', $this->zlen],             // Length of compressed data
+                    ['P', $this->len],              // Length of original data
+                ];
+            }
+
+            $footer = ZipStream::packFields($fields);
+            $this->zip->send($footer);
+        } else {
+            $footer = '';
+        }
+        $this->totalLength = $this->hlen->add($this->zlen)->add(Bigint::init(strlen($footer)));
+        $this->zip->addToCdr($this);
+    }
+
+    public function processStream(StreamInterface $stream): void
+    {
+        $this->zlen = new Bigint;
+        $this->len = new Bigint;
+
+        if ($this->zip->opt->isZeroHeader()) {
+            $this->processStreamWithZeroHeader($stream);
+        } else {
+            $this->processStreamWithComputedHeader($stream);
+        }
+    }
+
+    protected function processStreamWithZeroHeader(StreamInterface $stream): void
+    {
+        $this->bits |= self::BIT_ZERO_HEADER;
+        $this->addFileHeader();
+        $this->readStream($stream, self::COMPUTE | self::SEND);
+        $this->addFileFooter();
+    }
+
+    protected function readStream(StreamInterface $stream, ?int $options = null): void
+    {
+        $this->deflateInit();
+        while (!$stream->eof()) {
+            $data = $stream->read(self::CHUNKED_READ_BLOCK_SIZE);
+            $this->deflateData($stream, $data, $options);
+            if ($options & self::SEND) {
+                $this->zip->send($data);
+            }
+        }
+        $this->deflateFinish($options);
+    }
+
+    protected function deflateInit(): void
+    {
+        $this->hash = hash_init(self::HASH_ALGORITHM);
+        if ($this->method->equals(Method::DEFLATE())) {
+            $this->deflate = deflate_init(
+                ZLIB_ENCODING_RAW,
+                ['level' => $this->opt->getDeflateLevel()]
+            );
+        }
+    }
+
+    protected function deflateData(StreamInterface $stream, string &$data, ?int $options = null): void
+    {
+        if ($options & self::COMPUTE) {
+            $this->len = $this->len->add(BigInt::init(strlen($data)));
+            hash_update($this->hash, $data);
+        }
+        if ($this->deflate) {
+            $data = deflate_add(
+                $this->deflate,
+                $data,
+                $stream->eof()
+                    ? ZLIB_FINISH
+                    : ZLIB_NO_FLUSH
+            );
+        }
+        if ($options & self::COMPUTE) {
+            $this->zlen = $this->zlen->add(BigInt::init(strlen($data)));
+        }
+    }
+
+    protected function deflateFinish(?int $options = null): void
+    {
+        if ($options & self::COMPUTE) {
+            $this->crc = hexdec(hash_final($this->hash));
+        }
+    }
+
+    protected function processStreamWithComputedHeader(StreamInterface $stream): void
+    {
+        $this->readStream($stream, self::COMPUTE);
+        $stream->rewind();
+
+        // incremental compression with deflate_add
+        // makes this second read unnecessary
+        // but it is only available from PHP 7.0
+        if (!$this->deflate && $stream instanceof DeflateStream && $this->method->equals(Method::DEFLATE())) {
+            $stream->addDeflateFilter($this->opt->getDeflateLevel());
+            $this->zlen = new Bigint;
+            while (!$stream->eof()) {
+                $data = $stream->read(self::CHUNKED_READ_BLOCK_SIZE);
+                $this->zlen = $this->zlen->add(BigInt::init(strlen($data)));
+            }
+            $stream->rewind();
+        }
+
+        $this->addFileHeader();
+        $this->readStream($stream, self::SEND);
+        $this->addFileFooter();
+    }
+
+    /**
+     * Send CDR record for specified file.
+     *
+     * @return void
+     */
+    public function addCdrFile(): void
+    {
+        $name = static::filterFilename($this->name);
+
+        // get attributes
+        $comment = $this->opt->getComment();
+
+        // get dos timestamp
+        $time = static::dosTime($this->opt->getTime()->getTimestamp());
+
+        $footer = $this->buildZip64ExtraBlock();
+
+        $fields = [
+            ['V', ZipStream::CDR_FILE_SIGNATURE],   // Central file header signature
+            ['v', ZipStream::ZIP_VERSION_MADE_BY],  // Made by version
+            ['v', $this->version->getValue()],                  // Extract by version
+            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
+            ['v', $this->method->getValue()],                     // Compression method
+            ['V', $time],                           // Timestamp (DOS Format)
+            ['V', $this->crc],                      // CRC32
+            ['V', $this->zlen->getLowFF()],         // Compressed Data Length
+            ['V', $this->len->getLowFF()],          // Original Data Length
+            ['v', strlen($name)],                   // Length of filename
+            ['v', strlen($footer)],                 // Extra data len (see above)
+            ['v', strlen($comment)],                // Length of comment
+            ['v', 0],                               // Disk number
+            ['v', 0],                               // Internal File Attributes
+            ['V', 32],                              // External File Attributes
+            ['V', $this->ofs->getLowFF()]           // Relative offset of local header
+        ];
+
+        // pack fields, then append name and comment
+        $header = ZipStream::packFields($fields);
+
+        $data = $header . $name . $footer . $comment;
+        $this->zip->send($data);
+
+        // increment cdr offset
+        $this->zip->cdr_ofs = $this->zip->cdr_ofs->add(Bigint::init(strlen($data)));
+    }
+
+    /**
+     * @return Bigint
+     */
+    public function getTotalLength(): Bigint
+    {
+        return $this->totalLength;
+    }
+}

--- a/php/ZipStream/Option/Archive.php
+++ b/php/ZipStream/Option/Archive.php
@@ -1,0 +1,245 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Option;
+
+final class Archive
+{
+    const DEFAULT_DEFLATE_LEVEL = 6;
+    /**
+     * @var string
+     */
+    private $comment = '';
+    /**
+     * Size, in bytes, of the largest file to try
+     * and load into memory (used by
+     * addFileFromPath()).  Large files may also
+     * be compressed differently; see the
+     * 'largeFileMethod' option.
+     *
+     * @var int
+     */
+    private $largeFileSize = 20 * 1024 * 1024;
+    /**
+     * How to handle large files.  Legal values are
+     * ZipStream::METHOD_STORE (the default), or
+     * ZipStream::METHOD_DEFLATE. Store sends the file
+     * raw and is significantly
+     * faster, while ZipStream::METHOD_DEFLATE compresses the file
+     * and is much, much slower.  Note that deflate
+     * must compress the file twice and extremely
+     * slow.
+     *
+     * @var Method
+     */
+    private $largeFileMethod;
+    /**
+     * Boolean indicating whether or not to send
+     * the HTTP headers for this file.
+     *
+     * @var bool
+     */
+    private $sendHttpHeaders = false;
+    /**
+     * @var Callable
+     */
+    private $httpHeaderCallback = 'method';
+    /**
+     * Enable Zip64 extension, supporting very large
+     * archives (any size > 4 GB or file count > 64k)
+     *
+     * @var bool
+     */
+    private $enableZip64 = true;
+    /**
+     * Enable streaming files with single read where
+     * general purpose bit 3 indicates local file header
+     * contain zero values in crc and size fields,
+     * these appear only after file contents
+     * in data descriptor block.
+     *
+     * @var bool
+     */
+    private $zeroHeader = false;
+    /**
+     * Enable reading file stat for determining file size.
+     * When a 32-bit system reads file size that is
+     * over 2 GB, invalid value appears in file size
+     * due to integer overflow. Should be disabled on
+     * 32-bit systems with method addFileFromPath
+     * if any file may exceed 2 GB. In this case file
+     * will be read in blocks and correct size will be
+     * determined from content.
+     *
+     * @var bool
+     */
+    private $statFiles = true;
+    /**
+     * HTTP Content-Disposition.  Defaults to
+     * 'attachment', where
+     * FILENAME is the specified filename.
+     *
+     * Note that this does nothing if you are
+     * not sending HTTP headers.
+     *
+     * @var string
+     */
+    private $contentDisposition = 'attachment';
+    /**
+     * Note that this does nothing if you are
+     * not sending HTTP headers.
+     *
+     * @var string
+     */
+    private $contentType = 'application/x-zip';
+    /**
+     * @var int
+     */
+    private $deflateLevel = 6;
+
+    /**
+     * @var resource
+     */
+    private $outputStream;
+
+    /**
+     * Options constructor.
+     */
+    public function __construct()
+    {
+        $this->largeFileMethod = Method::STORE();
+        $this->outputStream = fopen('php://output', 'wb');
+    }
+
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(string $comment): void
+    {
+        $this->comment = $comment;
+    }
+
+    public function getLargeFileSize(): int
+    {
+        return $this->largeFileSize;
+    }
+
+    public function setLargeFileSize(int $largeFileSize): void
+    {
+        $this->largeFileSize = $largeFileSize;
+    }
+
+    public function getLargeFileMethod(): Method
+    {
+        return $this->largeFileMethod;
+    }
+
+    public function setLargeFileMethod(Method $largeFileMethod): void
+    {
+        $this->largeFileMethod = $largeFileMethod;
+    }
+
+    public function isSendHttpHeaders(): bool
+    {
+        return $this->sendHttpHeaders;
+    }
+
+    public function setSendHttpHeaders(bool $sendHttpHeaders): void
+    {
+        $this->sendHttpHeaders = $sendHttpHeaders;
+    }
+
+    public function getHttpHeaderCallback(): Callable
+    {
+        return $this->httpHeaderCallback;
+    }
+
+    public function setHttpHeaderCallback(Callable $httpHeaderCallback): void
+    {
+        $this->httpHeaderCallback = $httpHeaderCallback;
+    }
+
+    public function isEnableZip64(): bool
+    {
+        return $this->enableZip64;
+    }
+
+    public function setEnableZip64(bool $enableZip64): void
+    {
+        $this->enableZip64 = $enableZip64;
+    }
+
+    public function isZeroHeader(): bool
+    {
+        return $this->zeroHeader;
+    }
+
+    public function setZeroHeader(bool $zeroHeader): void
+    {
+        $this->zeroHeader = $zeroHeader;
+    }
+
+    public function isStatFiles(): bool
+    {
+        return $this->statFiles;
+    }
+
+    public function setStatFiles(bool $statFiles): void
+    {
+        $this->statFiles = $statFiles;
+    }
+
+    public function getContentDisposition(): string
+    {
+        return $this->contentDisposition;
+    }
+
+    public function setContentDisposition(string $contentDisposition): void
+    {
+        $this->contentDisposition = $contentDisposition;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+
+    public function setContentType(string $contentType): void
+    {
+        $this->contentType = $contentType;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getOutputStream()
+    {
+        return $this->outputStream;
+    }
+
+    /**
+     * @param resource $outputStream
+     */
+    public function setOutputStream($outputStream): void
+    {
+        $this->outputStream = $outputStream;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDeflateLevel(): int
+    {
+        return $this->deflateLevel;
+    }
+
+    /**
+     * @param int $deflateLevel
+     */
+    public function setDeflateLevel(int $deflateLevel): void
+    {
+        $this->deflateLevel = $deflateLevel;
+    }
+}

--- a/php/ZipStream/Option/File.php
+++ b/php/ZipStream/Option/File.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Option;
+
+use DateTime;
+
+final class File
+{
+    /**
+     * @var string
+     */
+    private $comment = '';
+    /**
+     * @var Method
+     */
+    private $method;
+    /**
+     * @var int
+     */
+    private $deflateLevel;
+    /**
+     * @var DateTime
+     */
+    private $time;
+
+    public function defaultTo(Archive $archiveOptions): void
+    {
+        $this->deflateLevel = $this->deflateLevel ?: $archiveOptions->getDeflateLevel();
+        $this->time = new DateTime();
+    }
+
+    /**
+     * @return string
+     */
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @param string $comment
+     */
+    public function setComment(string $comment): void
+    {
+        $this->comment = $comment;
+    }
+
+    /**
+     * @return Method
+     */
+    public function getMethod(): Method
+    {
+        return $this->method ?: Method::DEFLATE();
+    }
+
+    /**
+     * @param Method $method
+     */
+    public function setMethod(Method $method): void
+    {
+        $this->method = $method;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDeflateLevel(): int
+    {
+        return $this->deflateLevel ?: Archive::DEFAULT_DEFLATE_LEVEL;
+    }
+
+    /**
+     * @param int $deflateLevel
+     */
+    public function setDeflateLevel(int $deflateLevel): void
+    {
+        $this->deflateLevel = $deflateLevel;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getTime(): DateTime
+    {
+        return $this->time;
+    }
+
+    /**
+     * @param DateTime $time
+     */
+    public function setTime(DateTime $time): void
+    {
+        $this->time = $time;
+    }
+}

--- a/php/ZipStream/Option/Method.php
+++ b/php/ZipStream/Option/Method.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Option;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Methods enum
+ *
+ * @method static STORE(): Method
+ * @method static DEFLATE(): Method
+ */
+class Method extends Enum
+{
+    const STORE = 0x00;
+    const DEFLATE = 0x08;
+}

--- a/php/ZipStream/Option/Version.php
+++ b/php/ZipStream/Option/Version.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Option;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Class Version
+ * @package ZipStream\Option
+ *
+ * @method static STORE(): Version
+ * @method static DEFLATE(): Version
+ * @method static ZIP64(): Version
+ */
+class Version extends Enum
+{
+    const STORE = 0x000A; // 1.00
+    const DEFLATE = 0x0014; // 2.00
+    const ZIP64 = 0x002D; // 4.50
+}

--- a/php/ZipStream/Stream.php
+++ b/php/ZipStream/Stream.php
@@ -1,0 +1,256 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+/**
+ * Describes a data stream.
+ *
+ * Typically, an instance will wrap a PHP stream; this interface provides
+ * a wrapper around the most common operations, including serialization of
+ * the entire stream to a string.
+ */
+class Stream implements StreamInterface
+{
+    protected $stream;
+
+    public function __construct($stream)
+    {
+        $this->stream = $stream;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
+     * Closes the stream and any underlying resources.
+     *
+     * @return void
+     */
+    public function close(): void
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->detach();
+    }
+
+    /**
+     * Separates any underlying resources from the stream.
+     *
+     * After the stream has been detached, the stream is in an unusable state.
+     *
+     * @return resource|null Underlying PHP stream, if any
+     */
+    public function detach()
+    {
+        $result = $this->stream;
+        $this->stream = null;
+        return $result;
+    }
+
+    /**
+     * Reads all data from the stream into a string, from the beginning to end.
+     *
+     * This method MUST attempt to seek to the beginning of the stream before
+     * reading data and read the stream until the end is reached.
+     *
+     * Warning: This could attempt to load a large amount of data into memory.
+     *
+     * This method MUST NOT raise an exception in order to conform with PHP's
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
+     * @return string
+     */
+    public function __toString(): string
+    {
+        try {
+            $this->seek(0);
+        } catch (\RuntimeException $e) {}
+        return (string) stream_get_contents($this->stream);
+    }
+
+    /**
+     * Seek to a position in the stream.
+     *
+     * @link http://www.php.net/manual/en/function.fseek.php
+     * @param int $offset Stream offset
+     * @param int $whence Specifies how the cursor position will be calculated
+     *     based on the seek offset. Valid values are identical to the built-in
+     *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
+     *     offset bytes SEEK_CUR: Set position to current location plus offset
+     *     SEEK_END: Set position to end-of-stream plus offset.
+     * @throws \RuntimeException on failure.
+     */
+    public function seek($offset, $whence = SEEK_SET): void
+    {
+        if (!$this->isSeekable()) {
+            throw new RuntimeException;
+        }
+        if (fseek($this->stream, $offset, $whence) !== 0) {
+            throw new RuntimeException;
+        }
+    }
+
+    /**
+     * Returns whether or not the stream is seekable.
+     *
+     * @return bool
+     */
+    public function isSeekable(): bool
+    {
+        return (bool)$this->getMetadata('seekable');
+    }
+
+    /**
+     * Get stream metadata as an associative array or retrieve a specific key.
+     *
+     * The keys returned are identical to the keys returned from PHP's
+     * stream_get_meta_data() function.
+     *
+     * @link http://php.net/manual/en/function.stream-get-meta-data.php
+     * @param string $key Specific metadata to retrieve.
+     * @return array|mixed|null Returns an associative array if no key is
+     *     provided. Returns a specific key value if a key is provided and the
+     *     value is found, or null if the key is not found.
+     */
+    public function getMetadata($key = null)
+    {
+        $metadata = stream_get_meta_data($this->stream);
+        return $key !== null ? @$metadata[$key] : $metadata;
+    }
+
+    /**
+     * Get the size of the stream if known.
+     *
+     * @return int|null Returns the size in bytes if known, or null if unknown.
+     */
+    public function getSize(): ?int
+    {
+        $stats = fstat($this->stream);
+        return $stats['size'];
+    }
+
+    /**
+     * Returns the current position of the file read/write pointer
+     *
+     * @return int Position of the file pointer
+     * @throws \RuntimeException on error.
+     */
+    public function tell(): int
+    {
+        $position = ftell($this->stream);
+        if ($position === false) {
+            throw new RuntimeException;
+        }
+        return $position;
+    }
+
+    /**
+     * Returns true if the stream is at the end of the stream.
+     *
+     * @return bool
+     */
+    public function eof(): bool
+    {
+        return feof($this->stream);
+    }
+
+    /**
+     * Seek to the beginning of the stream.
+     *
+     * If the stream is not seekable, this method will raise an exception;
+     * otherwise, it will perform a seek(0).
+     *
+     * @see seek()
+     * @link http://www.php.net/manual/en/function.fseek.php
+     * @throws \RuntimeException on failure.
+     */
+    public function rewind(): void
+    {
+        $this->seek(0);
+    }
+
+    /**
+     * Write data to the stream.
+     *
+     * @param string $string The string that is to be written.
+     * @throws \RuntimeException on failure.
+     */
+    public function write($string): void
+    {
+        if (!$this->isWritable()) {
+            throw new RuntimeException;
+        }
+        if (fwrite($this->stream, $string) === false) {
+            throw new RuntimeException;
+        }
+    }
+
+    /**
+     * Returns whether or not the stream is writable.
+     *
+     * @return bool
+     */
+    public function isWritable(): bool
+    {
+        return preg_match('/[waxc+]/', $this->getMetadata('mode')) === 1;
+    }
+
+    /**
+     * Read data from the stream.
+     *
+     * @param int $length Read up to $length bytes from the object and return
+     *     them. Fewer than $length bytes may be returned if underlying stream
+     *     call returns fewer bytes.
+     * @return string Returns the data read from the stream, or an empty string
+     *     if no bytes are available.
+     * @throws \RuntimeException if an error occurs.
+     */
+    public function read($length): string
+    {
+        if (!$this->isReadable()) {
+            throw new RuntimeException;
+        }
+        $result = fread($this->stream, $length);
+        if ($result === false) {
+            throw new RuntimeException;
+        }
+        return $result;
+    }
+
+    /**
+     * Returns whether or not the stream is readable.
+     *
+     * @return bool
+     */
+    public function isReadable(): bool
+    {
+        return preg_match('/[r+]/', $this->getMetadata('mode')) === 1;
+    }
+
+    /**
+     * Returns the remaining contents in a string
+     *
+     * @return string
+     * @throws \RuntimeException if unable to read or an error occurs while
+     *     reading.
+     */
+    public function getContents(): string
+    {
+        if (!$this->isReadable()) {
+            throw new RuntimeException;
+        }
+        $result = stream_get_contents($this->stream);
+        if ($result === false) {
+            throw new RuntimeException;
+        }
+        return $result;
+    }
+}

--- a/php/ZipStream/ZipStream.php
+++ b/php/ZipStream/ZipStream.php
@@ -1,0 +1,560 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream;
+
+use Psr\Http\Message\StreamInterface;
+use ZipStream\Exception\OverflowException;
+use ZipStream\Option\Archive as ArchiveOptions;
+use ZipStream\Option\File as FileOptions;
+use ZipStream\Option\Version;
+
+/**
+ * ZipStream
+ *
+ * Streamed, dynamically generated zip archives.
+ *
+ * Usage:
+ *
+ * Streaming zip archives is a simple, three-step process:
+ *
+ * 1.  Create the zip stream:
+ *
+ *     $zip = new ZipStream('example.zip');
+ *
+ * 2.  Add one or more files to the archive:
+ *
+ *      * add first file
+ *     $data = file_get_contents('some_file.gif');
+ *     $zip->addFile('some_file.gif', $data);
+ *
+ *      * add second file
+ *     $data = file_get_contents('some_file.gif');
+ *     $zip->addFile('another_file.png', $data);
+ *
+ * 3.  Finish the zip stream:
+ *
+ *     $zip->finish();
+ *
+ * You can also add an archive comment, add comments to individual files,
+ * and adjust the timestamp of files. See the API documentation for each
+ * method below for additional information.
+ *
+ * Example:
+ *
+ *   // create a new zip stream object
+ *   $zip = new ZipStream('some_files.zip');
+ *
+ *   // list of local files
+ *   $files = array('foo.txt', 'bar.jpg');
+ *
+ *   // read and add each file to the archive
+ *   foreach ($files as $path)
+ *     $zip->addFile($path, file_get_contents($path));
+ *
+ *   // write archive footer to stream
+ *   $zip->finish();
+ */
+class ZipStream
+{
+    const ZIP_VERSION_MADE_BY = 0x031E; // 3.00 on Unix
+
+    const FILE_HEADER_SIGNATURE = 0x04034b50;
+    const CDR_FILE_SIGNATURE = 0x02014b50;
+    const CDR_EOF_SIGNATURE = 0x06054b50;
+    const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
+    const ZIP64_CDR_EOF_SIGNATURE = 0x06064b50;
+    const ZIP64_CDR_LOCATOR_SIGNATURE = 0x07064b50;
+
+    /**
+     * Global Options
+     *
+     * @var ArchiveOptions
+     */
+    public $opt;
+
+    /**
+     * @var array
+     */
+    public $files = [];
+
+    /**
+     * @var integer
+     */
+    public $cdr_ofs;
+
+    /**
+     * @var integer
+     */
+    public $ofs;
+
+    /**
+     * @var bool
+     */
+    protected $need_headers;
+
+    /**
+     * @var null|String
+     */
+    protected $output_name;
+
+    /**
+     * Create a new ZipStream object.
+     *
+     * Parameters:
+     *
+     * @param String $name - Name of output file (optional).
+     * @param ArchiveOptions $opt - Archive Options
+     *
+     * Large File Support:
+     *
+     * By default, the method addFileFromPath() will send send files
+     * larger than 20 megabytes along raw rather than attempting to
+     * compress them.  You can change both the maximum size and the
+     * compression behavior using the large_file_* options above, with the
+     * following caveats:
+     *
+     * * For "small" files (e.g. files smaller than large_file_size), the
+     *   memory use can be up to twice that of the actual file.  In other
+     *   words, adding a 10 megabyte file to the archive could potentially
+     *   occupy 20 megabytes of memory.
+     *
+     * * Enabling compression on large files (e.g. files larger than
+     *   large_file_size) is extremely slow, because ZipStream has to pass
+     *   over the large file once to calculate header information, and then
+     *   again to compress and send the actual data.
+     *
+     * Examples:
+     *
+     *   // create a new zip file named 'foo.zip'
+     *   $zip = new ZipStream('foo.zip');
+     *
+     *   // create a new zip file named 'bar.zip' with a comment
+     *   $zip = new ZipStream('bar.zip', array(
+     *     'comment' => 'this is a comment for the zip file.',
+     *   ));
+     *
+     * Notes:
+     *
+     * If you do not set a filename, then this library _DOES NOT_ send HTTP
+     * headers by default.  This behavior is to allow software to send its
+     * own headers (including the filename), and still use this library.
+     */
+    public function __construct(?string $name = null, ?ArchiveOptions $opt = null)
+    {
+        $this->opt = $opt ?: new ArchiveOptions();
+
+        $this->output_name = $name;
+        $this->need_headers = $name && $this->opt->isSendHttpHeaders();
+
+        $this->cdr_ofs = new Bigint;
+        $this->ofs = new Bigint;
+    }
+
+    /**
+     * addFile
+     *
+     * Add a file to the archive.
+     *
+     * @param String $name - path of file in archive (including directory).
+     * @param String $data - contents of file
+     * @param FileOptions $options
+     *
+     * File Options:
+     *  time     - Last-modified timestamp (seconds since the epoch) of
+     *             this file.  Defaults to the current time.
+     *  comment  - Comment related to this file.
+     *  method   - Storage method for file ("store" or "deflate")
+     *
+     * Examples:
+     *
+     *   // add a file named 'foo.txt'
+     *   $data = file_get_contents('foo.txt');
+     *   $zip->addFile('foo.txt', $data);
+     *
+     *   // add a file named 'bar.jpg' with a comment and a last-modified
+     *   // time of two hours ago
+     *   $data = file_get_contents('bar.jpg');
+     *   $zip->addFile('bar.jpg', $data, array(
+     *     'time'    => time() - 2 * 3600,
+     *     'comment' => 'this is a comment about bar.jpg',
+     *   ));
+     */
+    public function addFile(string $name, string $data, ?FileOptions $options = null): void
+    {
+        $options = $options ?: new FileOptions();
+        $options->defaultTo($this->opt);
+
+        $file = new File($this, $name, $options);
+        $file->processData($data);
+    }
+
+    /**
+     * addFileFromPath
+     *
+     * Add a file at path to the archive.
+     *
+     * Note that large files may be compressed differently than smaller
+     * files; see the "Large File Support" section above for more
+     * information.
+     *
+     * @param String $name - name of file in archive (including directory path).
+     * @param String $path - path to file on disk (note: paths should be encoded using
+     *          UNIX-style forward slashes -- e.g '/path/to/some/file').
+     * @param FileOptions $options
+     *
+     * File Options:
+     *  time     - Last-modified timestamp (seconds since the epoch) of
+     *             this file.  Defaults to the current time.
+     *  comment  - Comment related to this file.
+     *  method   - Storage method for file ("store" or "deflate")
+     *
+     * Examples:
+     *
+     *   // add a file named 'foo.txt' from the local file '/tmp/foo.txt'
+     *   $zip->addFileFromPath('foo.txt', '/tmp/foo.txt');
+     *
+     *   // add a file named 'bigfile.rar' from the local file
+     *   // '/usr/share/bigfile.rar' with a comment and a last-modified
+     *   // time of two hours ago
+     *   $path = '/usr/share/bigfile.rar';
+     *   $zip->addFileFromPath('bigfile.rar', $path, array(
+     *     'time'    => time() - 2 * 3600,
+     *     'comment' => 'this is a comment about bar.jpg',
+     *   ));
+     *
+     * @return void
+     * @throws \ZipStream\Exception\FileNotFoundException
+     * @throws \ZipStream\Exception\FileNotReadableException
+     */
+    public function addFileFromPath(string $name, string $path, ?FileOptions $options = null): void
+    {
+        $options = $options ?: new FileOptions();
+        $options->defaultTo($this->opt);
+
+        $file = new File($this, $name, $options);
+        $file->processPath($path);
+    }
+
+    /**
+     * addFileFromStream
+     *
+     * Add an open stream to the archive.
+     *
+     * @param String $name - path of file in archive (including directory).
+     * @param Resource $stream - contents of file as a stream resource
+     * @param FileOptions $options
+     *
+     * File Options:
+     *  time     - Last-modified timestamp (seconds since the epoch) of
+     *             this file.  Defaults to the current time.
+     *  comment  - Comment related to this file.
+     *
+     * Examples:
+     *
+     *   // create a temporary file stream and write text to it
+     *   $fp = tmpfile();
+     *   fwrite($fp, 'The quick brown fox jumped over the lazy dog.');
+     *
+     *   // add a file named 'streamfile.txt' from the content of the stream
+     *   $x->addFile_from_stream('streamfile.txt', $fp);
+     *
+     * @return void
+     */
+    public function addFileFromStream(string $name, $stream, ?FileOptions $options = null): void
+    {
+        $options = $options ?: new FileOptions();
+        $options->defaultTo($this->opt);
+
+        $file = new File($this, $name, $options);
+        $file->processStream(new DeflateStream($stream));
+    }
+
+    /**
+     * addFileFromPsr7Stream
+     *
+     * Add an open stream to the archive.
+     *
+     * @param String $name - path of file in archive (including directory).
+     * @param StreamInterface $stream - contents of file as a stream resource
+     * @param FileOptions $options
+     *
+     * File Options:
+     *  time     - Last-modified timestamp (seconds since the epoch) of
+     *             this file.  Defaults to the current time.
+     *  comment  - Comment related to this file.
+     *
+     * Examples:
+     *
+     *   // create a temporary file stream and write text to it
+     *   $fp = tmpfile();
+     *   fwrite($fp, 'The quick brown fox jumped over the lazy dog.');
+     *
+     *   // add a file named 'streamfile.txt' from the content of the stream
+     *   $x->addFile_from_stream('streamfile.txt', $fp);
+     *
+     * @return void
+     */
+    public function addFileFromPsr7Stream(
+        string $name,
+        StreamInterface $stream,
+        ?FileOptions $options = null
+    ): void {
+        $options = $options ?: new FileOptions();
+        $options->defaultTo($this->opt);
+
+        $file = new File($this, $name, $options);
+        $file->processStream($stream);
+    }
+
+    /**
+     * finish
+     *
+     * Write zip footer to stream.
+     *
+     *  Example:
+     *
+     *   // add a list of files to the archive
+     *   $files = array('foo.txt', 'bar.jpg');
+     *   foreach ($files as $path)
+     *     $zip->addFile($path, file_get_contents($path));
+     *
+     *   // write footer to stream
+     *   $zip->finish();
+     * @return void
+     *
+     * @throws OverflowException
+     */
+    public function finish(): void
+    {
+        // add trailing cdr file records
+        foreach ($this->files as $file) {
+            $file->addCdrFile();
+        }
+
+        // Add 64bit headers (if applicable)
+        if (count($this->files) >= 0xFFFF ||
+            $this->cdr_ofs->isOver32() ||
+            $this->ofs->isOver32()) {
+            if (!$this->opt->isEnableZip64()) {
+                throw new OverflowException();
+            }
+
+            $this->addCdr64Eof();
+            $this->addCdr64Locator();
+        }
+
+        // add trailing cdr eof record
+        $this->addCdrEof();
+
+        // The End
+        $this->clear();
+    }
+
+    /**
+     * Send ZIP64 CDR EOF (Central Directory Record End-of-File) record.
+     *
+     * @return void
+     */
+    protected function addCdr64Eof(): void
+    {
+        $num_files = count($this->files);
+        $cdr_length = $this->cdr_ofs;
+        $cdr_offset = $this->ofs;
+
+        $fields = [
+            ['V', static::ZIP64_CDR_EOF_SIGNATURE],     // ZIP64 end of central file header signature
+            ['P', 44],                                  // Length of data below this header (length of block - 12) = 44
+            ['v', static::ZIP_VERSION_MADE_BY],         // Made by version
+            ['v', Version::ZIP64],                      // Extract by version
+            ['V', 0x00],                                // disk number
+            ['V', 0x00],                                // no of disks
+            ['P', $num_files],                          // no of entries on disk
+            ['P', $num_files],                          // no of entries in cdr
+            ['P', $cdr_length],                         // CDR size
+            ['P', $cdr_offset],                         // CDR offset
+        ];
+
+        $ret = static::packFields($fields);
+        $this->send($ret);
+    }
+
+    /**
+     * Create a format string and argument list for pack(), then call
+     * pack() and return the result.
+     *
+     * @param array $fields
+     * @return string
+     */
+    public static function packFields(array $fields): string
+    {
+        $fmt = '';
+        $args = [];
+
+        // populate format string and argument list
+        foreach ($fields as [$format, $value]) {
+            if ($format === 'P') {
+                $fmt .= 'VV';
+                if ($value instanceof Bigint) {
+                    $args[] = $value->getLow32();
+                    $args[] = $value->getHigh32();
+                } else {
+                    $args[] = $value;
+                    $args[] = 0;
+                }
+            } else {
+                if ($value instanceof Bigint) {
+                    $value = $value->getLow32();
+                }
+                $fmt .= $format;
+                $args[] = $value;
+            }
+        }
+
+        // prepend format string to argument list
+        array_unshift($args, $fmt);
+
+        // build output string from header and compressed data
+        return pack(...$args);
+    }
+
+    /**
+     * Send string, sending HTTP headers if necessary.
+     *
+     * @param String $str
+     * @return void
+     */
+    public function send(string $str): void
+    {
+        if ($this->need_headers) {
+            $this->sendHttpHeaders();
+        }
+        $this->need_headers = false;
+
+        fwrite($this->opt->getOutputStream(), $str);
+    }
+
+    /**
+     * Send HTTP headers for this stream.
+     *
+     * @return void
+     */
+    protected function sendHttpHeaders(): void
+    {
+        // grab content disposition
+        $disposition = $this->opt->getContentDisposition();
+
+        if ($this->output_name) {
+            // Various different browsers dislike various characters here. Strip them all for safety.
+            $safe_output = trim(str_replace(['"', "'", '\\', ';', "\n", "\r"], '', $this->output_name));
+
+            // Check if we need to UTF-8 encode the filename
+            $urlencoded = rawurlencode($safe_output);
+            $disposition .= "; filename*=UTF-8''{$urlencoded}";
+        }
+
+        $headers = array(
+            'Content-Type' => $this->opt->getContentType(),
+            'Content-Disposition' => $disposition,
+            'Pragma' => 'public',
+            'Cache-Control' => 'public, must-revalidate',
+            'Content-Transfer-Encoding' => 'binary'
+        );
+
+        $call = $this->opt->getHttpHeaderCallback();
+        foreach ($headers as $key => $val) {
+            $call("$key: $val");
+        }
+    }
+
+    /**
+     * Send ZIP64 CDR Locator (Central Directory Record Locator) record.
+     *
+     * @return void
+     */
+    protected function addCdr64Locator(): void
+    {
+        $cdr_offset = $this->ofs->add($this->cdr_ofs);
+
+        $fields = [
+            ['V', static::ZIP64_CDR_LOCATOR_SIGNATURE], // ZIP64 end of central file header signature
+            ['V', 0x00],                                // Disc number containing CDR64EOF
+            ['P', $cdr_offset],                         // CDR offset
+            ['V', 1],                                   // Total number of disks
+        ];
+
+        $ret = static::packFields($fields);
+        $this->send($ret);
+    }
+
+    /**
+     * Send CDR EOF (Central Directory Record End-of-File) record.
+     *
+     * @return void
+     */
+    protected function addCdrEof(): void
+    {
+        $num_files = count($this->files);
+        $cdr_length = $this->cdr_ofs;
+        $cdr_offset = $this->ofs;
+
+        // grab comment (if specified)
+        $comment = $this->opt->getComment();
+
+        $fields = [
+            ['V', static::CDR_EOF_SIGNATURE],   // end of central file header signature
+            ['v', 0x00],                        // disk number
+            ['v', 0x00],                        // no of disks
+            ['v', min($num_files, 0xFFFF)],     // no of entries on disk
+            ['v', min($num_files, 0xFFFF)],     // no of entries in cdr
+            ['V', $cdr_length->getLowFF()],     // CDR size
+            ['V', $cdr_offset->getLowFF()],     // CDR offset
+            ['v', strlen($comment)],            // Zip Comment size
+        ];
+
+        $ret = static::packFields($fields) . $comment;
+        $this->send($ret);
+    }
+
+    /**
+     * Clear all internal variables. Note that the stream object is not
+     * usable after this.
+     *
+     * @return void
+     */
+    protected function clear(): void
+    {
+        $this->files = [];
+        $this->ofs = new Bigint;
+        $this->cdr_ofs = new Bigint;
+        $this->opt = [];
+    }
+
+    /**
+     * Is this file larger than large_file_size?
+     *
+     * @param string $path
+     * @return Boolean|null
+     */
+    public function isLargeFile(string $path): bool
+    {
+        if (!$this->opt->isStatFiles()) {
+            return false;
+        }
+        $stat = stat($path);
+        return $stat['size'] > $this->opt->getLargeFileSize();
+    }
+
+    /**
+     * Save file attributes for trailing CDR record.
+     *
+     * @param File $file
+     * @return void
+     */
+    public function addToCdr(File $file): void
+    {
+        $file->ofs = $this->ofs;
+        $this->ofs = $this->ofs->add($file->getTotalLength());
+        $this->files[] = $file;
+    }
+}

--- a/php/index.php
+++ b/php/index.php
@@ -27,6 +27,7 @@ require(__DIR__ . '/helpers/getGraphHeader.php');
 require(__DIR__ . '/helpers/getHashedString.php');
 require(__DIR__ . '/helpers/hasPermissions.php');
 require(__DIR__ . '/helpers/search.php');
+require(__DIR__ . '/MyCLabs/Enum.php');
 
 // Define the called function
 if (isset($_POST['function']))     $fn = $_POST['function'];


### PR DESCRIPTION
Hello.

First of all, thank you for the gallery and subalbums. It's totally awesome!

There was a problem with my albums: they tend to occupy a lot of space (like 10+Gb). And were way to long to create. So I had to prepare zip files before the first client requests an archive.

With this patch no additional files are created, zip file is streamed right away (and due to low compression rate there is almost no overhead in terms of CPU).
I also had to change fnNotFound() slightly to make it easier to guess what's wrong. It looks to be useful anyway.

I understand that the patch doesn't meet guidelines. As soon as you like the idea itself - I will tidy up things.
I also used code from https://github.com/maennchen/ZipStream-PHP (MIT)
and https://github.com/php-fig/http-message (MIT)