### PR TITLE
Fixed "Show Log" for MySQL 8.0.1

### DIFF
--- a/php/Modules/Log.php
+++ b/php/Modules/Log.php
@@ -34,7 +34,7 @@ final class Log {
 		$sysstamp = time();
 
 		// Save in database
-		$query  = Database::prepare($connection, "INSERT INTO ? (time, type, function, line, text) VALUES ('?', '?', '?', '?', '?')", array(LYCHEE_TABLE_LOG, $sysstamp, $type, $function, $line, $text));
+		$query  = Database::prepare($connection, "INSERT INTO ? (time, type, `function`, line, text) VALUES ('?', '?', '?', '?', '?')", array(LYCHEE_TABLE_LOG, $sysstamp, $type, $function, $line, $text));
 		$result = Database::execute($connection, $query, null, null);
 
 		if ($result===false) return false;

--- a/plugins/Log/index.php
+++ b/plugins/Log/index.php
@@ -32,7 +32,7 @@ if ((isset($_SESSION['login'])&&$_SESSION['login']===true)&&
 	(isset($_SESSION['identifier'])&&$_SESSION['identifier']===Settings::get()['identifier'])) {
 
 	// Result
-	$query  = Database::prepare(Database::get(), "SELECT FROM_UNIXTIME(time), type, function, line, text FROM ?", array(LYCHEE_TABLE_LOG));
+	$query  = Database::prepare(Database::get(), "SELECT FROM_UNIXTIME(time), type, `function`, line, text FROM ?", array(LYCHEE_TABLE_LOG));
 	$result = Database::get()->query($query);
 
 	// Output


### PR DESCRIPTION
"lychee_log" MySQL table has a "function" column. In MySQL 8.0.1 "function" became a reserved word. This word has to be escaped in SQL queries.

How to reproduce the issue (step-by-step):
1. Install Lychee with MySQL v.8.0.1 or later.
2. Click Settings - Show Log.
3. Error 500 is displayed.