### PR TITLE
mimetype detection enhancement - when importing a photo via Link and Lychee complains that "Photo type not supported"

### DIFF
--- a/php/Modules/Import.php
+++ b/php/Modules/Import.php
@@ -59,11 +59,30 @@ final class Import {
 
 			// Verify image
 			$type = @exif_imagetype($url);
-			if (!in_array($type, Photo::$validTypes, true)) {
-				$error = true;
-				Log::error(Database::get(), __METHOD__, __LINE__, 'Photo type not supported (' . $url . ')');
-				continue;
+
+			if ($type !== false) {
+				if (!in_array($type, Photo::$validTypes, true)) {
+					$error = true;
+					Log::error(Database::get(), __METHOD__, __LINE__, 'Photo type not supported (' . $url . ')');
+					continue;
+				}
+			} else {
+				// when exif_imagetype fails, make one more attempt to detect mime type using getimagesize:
+				$type2 = @getimagesize($url);
+
+				if (isset($type2['mime'])) {
+					if (!in_array($type2['mime'], Photo::$validTypes2, true)) {
+						$error = true;
+						Log::error(Database::get(), __METHOD__, __LINE__, 'Photo type not supported (' . $url . ')');
+						continue;
+					}
+				} else {
+					$error = true;
+					Log::error(Database::get(), __METHOD__, __LINE__, 'Photo type not supported (' . $url . ')');
+					continue;
+				}
 			}
+
 
 			$filename = pathinfo($url, PATHINFO_FILENAME) . $extension;
 			$tmp_name = LYCHEE_DATA . $filename;

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -16,6 +16,13 @@ final class Photo {
 		IMAGETYPE_PNG
 	);
 
+	public static $validTypes2 = array(
+		'image/jpg',
+		'image/jpeg',
+		'image/png',
+		'image/gif'
+	);
+
 	public static $validExtensions = array(
 		'.jpg',
 		'.jpeg',


### PR DESCRIPTION
hello!

i am recently experiencing frequent errors when trying to import pictures directly from Facebook, Lychee cant detect the mime type of the given picture file. 

this happens because for the given photo, `exif_imagetype` complains that:

```
PHP Notice:  exif_imagetype(): Read error!
```

For the same image, the `getimagesize` can detect the mime type, please see below:

```
[http_offline@greenhat-30 TEST]$ cat mime_type_detect.php 
<?php

$url = 'https://scontent.fath5-1.fna.fbcdn.net/v/t1.0-9/72110633_114060826671623_3491471948204998656_n.jpg?_nc_cat=103&_nc_oc=AQllCq08DT0Y9KCgZiio9he1sc_KUDMpVTIaEUZBfG5kMRPIXxdDXIMUOmwia2vaPI0&_nc_ht=scontent.fath5-1.fna&oh=9d3ba6b8b9907ed6727a1adcaa59f8ef&oe=5E231DB1';

var_dump(exif_imagetype($url));
var_dump(getimagesize($url));
[http_offline@greenhat-30 TEST]$ php mime_type_detect.php 
PHP Notice:  exif_imagetype(): Read error! in /php_basedir/TEST/mime_type_detect.php on line 5
bool(false)
array(7) {
  [0]=>
  int(720)
  [1]=>
  int(720)
  [2]=>
  int(2)
  [3]=>
  string(24) "width="720" height="720""
  ["bits"]=>
  int(8)
  ["channels"]=>
  int(3)
  ["mime"]=>
  string(10) "image/jpeg"
}
[http_offline@greenhat-30 TEST]$ 
```

based on the above evidence, i added an extra step in the `Import.php` Module , plus an array in `Photo.php`.

here is a link to another FB photo that Lychee fails to import: [picture example](https://www.facebook.com/Life.Is.M.Power/photos/a.1000987626586504/2725437717474811/?type=3&theater&ifg=1). right click on the image, to get the actual link to picture (this link has an expiration date, FB changes them periodically)

Please check and let me know what you think?